### PR TITLE
fix(topbar): add beta label to selected app

### DIFF
--- a/components/topbar/src/application-menu.tsx
+++ b/components/topbar/src/application-menu.tsx
@@ -60,6 +60,7 @@ export const ApplicationMenu = (
               ? (currentSelection.label ?? appLabel(t, currentSelection.id))
               // FIXME: use translateable placeholder
               : ""}
+            {currentSelection?.beta && <BetaBadge />}
           </span>
         </MenuButton>
       </MenuTrigger>


### PR DESCRIPTION
The selected application in the app menu should still have the beta label.

![image](https://github.com/AxisCommunications/fluent-components/assets/1499470/ee37120c-06a7-4e6c-ab77-ffcb7740962f)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
