### PR TITLE
chore: set fixed commit prefix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 
 updates:
   - package-ecosystem: "npm"
+    commit-message:
+      prefix: "chore(deps)"
     directory: "/"
     groups:
       toolchain:


### PR DESCRIPTION
Add explicit prefix to dependabot to make commit linter happy (following conventional commits).

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
