### PR TITLE
chore(deps): clear dev-deps listed as peers

### DIFF
--- a/components/notification-bar/package.json
+++ b/components/notification-bar/package.json
@@ -33,10 +33,6 @@
     "test:watch": "vitest watch"
   },
   "devDependencies": {
-    "@fluentui/react-components": "^9.34.2",
-    "@fluentui/react-icons": "^2.0.219",
-    "@fluentui/react-utilities": "^9.14.2",
-    "@griffel/react": "^1.5.16",
     "@testing-library/jest-dom": "^5.16.5",
     "@types/react": "^17.0.67",
     "@types/react-dom": "^17.0.21",

--- a/components/password-input/package.json
+++ b/components/password-input/package.json
@@ -33,10 +33,6 @@
     "test:watch": "vitest watch"
   },
   "devDependencies": {
-    "@fluentui/react-components": "^9.34.2",
-    "@fluentui/react-icons": "^2.0.219",
-    "@fluentui/react-utilities": "^9.14.2",
-    "@griffel/react": "^1.5.16",
     "@testing-library/jest-dom": "^5.16.5",
     "@types/react": "^17.0.67",
     "@types/react-dom": "^17.0.21",

--- a/components/slider/package.json
+++ b/components/slider/package.json
@@ -24,10 +24,6 @@
     "test:watch": "vitest watch"
   },
   "devDependencies": {
-    "@fluentui/react-components": "^9.34.2",
-    "@fluentui/react-icons": "^2.0.219",
-    "@fluentui/react-utilities": "^9.14.2",
-    "@griffel/react": "^1.5.16",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^14.5.1",
@@ -38,7 +34,6 @@
     "jsdom": "^21.1.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "scheduler": "^0.20.0",
     "typescript": "^4.5.5",
     "vitest": "^0.34.6"
   },

--- a/components/stepper/package.json
+++ b/components/stepper/package.json
@@ -24,10 +24,6 @@
     "test:watch": "vitest watch"
   },
   "devDependencies": {
-    "@fluentui/react-components": "^9.34.2",
-    "@fluentui/react-icons": "^2.0.219",
-    "@fluentui/react-utilities": "^9.14.2",
-    "@griffel/react": "^1.5.16",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12.1.5",
     "@types/react": "^17.0.67",
@@ -37,7 +33,6 @@
     "jsdom": "^21.1.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "scheduler": "^0.20.0",
     "typescript": "^4.5.5",
     "vitest": "^0.34.6"
   },

--- a/components/topbar/package.json
+++ b/components/topbar/package.json
@@ -33,10 +33,6 @@
     "test:watch": "vitest watch"
   },
   "devDependencies": {
-    "@fluentui/react-components": "^9.34.2",
-    "@fluentui/react-icons": "^2.0.219",
-    "@fluentui/react-utilities": "^9.14.2",
-    "@griffel/react": "^1.5.16",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12.1.5",
     "@types/react": "^17.0.67",
@@ -46,7 +42,6 @@
     "jsdom": "^21.1.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "scheduler": "^0.20.0",
     "typescript": "^4.5.5",
     "vitest": "^0.34.6"
   },

--- a/icons/package.json
+++ b/icons/package.json
@@ -37,7 +37,6 @@
     "react:svg:unfill": "find ./dist/react-svg -type f -name '*.svg' -exec sed -i.bak 's/fill=\"none\"//g' '{}' \\; && find ./dist/react-svg -type f -name '*.bak' -delete"
   },
   "devDependencies": {
-    "@griffel/react": "^1.5.16",
     "@svgr/core": "^5.5.0",
     "@types/node": "^18.0.0",
     "@types/react": "^18.2.24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
         version: 4.9.5
 
   components/notification-bar:
-    devDependencies:
+    dependencies:
       '@fluentui/react-components':
         specifier: ^9.34.2
         version: 9.34.2(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0)
@@ -66,6 +66,7 @@ importers:
       '@griffel/react':
         specifier: ^1.5.16
         version: 1.5.16(react@17.0.2)
+    devDependencies:
       '@testing-library/jest-dom':
         specifier: ^5.16.5
         version: 5.16.5
@@ -98,7 +99,7 @@ importers:
         version: 0.34.6(jsdom@21.1.1)
 
   components/password-input:
-    devDependencies:
+    dependencies:
       '@fluentui/react-components':
         specifier: ^9.34.2
         version: 9.34.2(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0)
@@ -111,6 +112,7 @@ importers:
       '@griffel/react':
         specifier: ^1.5.16
         version: 1.5.16(react@17.0.2)
+    devDependencies:
       '@testing-library/jest-dom':
         specifier: ^5.16.5
         version: 5.16.5
@@ -143,7 +145,7 @@ importers:
         version: 0.34.6(jsdom@21.1.1)
 
   components/slider:
-    devDependencies:
+    dependencies:
       '@fluentui/react-components':
         specifier: ^9.34.2
         version: 9.34.2(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0)
@@ -156,6 +158,10 @@ importers:
       '@griffel/react':
         specifier: ^1.5.16
         version: 1.5.16(react@17.0.2)
+      scheduler:
+        specifier: ^0.20.0
+        version: 0.20.0
+    devDependencies:
       '@testing-library/jest-dom':
         specifier: ^5.16.5
         version: 5.16.5
@@ -186,9 +192,6 @@ importers:
       react-dom:
         specifier: ^17.0.2
         version: 17.0.2(react@17.0.2)
-      scheduler:
-        specifier: ^0.20.0
-        version: 0.20.0
       typescript:
         specifier: ^4.5.5
         version: 4.9.5
@@ -197,7 +200,7 @@ importers:
         version: 0.34.6(jsdom@21.1.1)
 
   components/stepper:
-    devDependencies:
+    dependencies:
       '@fluentui/react-components':
         specifier: ^9.34.2
         version: 9.34.2(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0)
@@ -210,6 +213,10 @@ importers:
       '@griffel/react':
         specifier: ^1.5.16
         version: 1.5.16(react@17.0.2)
+      scheduler:
+        specifier: ^0.20.0
+        version: 0.20.0
+    devDependencies:
       '@testing-library/jest-dom':
         specifier: ^5.16.5
         version: 5.16.5
@@ -237,9 +244,6 @@ importers:
       react-dom:
         specifier: ^17.0.2
         version: 17.0.2(react@17.0.2)
-      scheduler:
-        specifier: ^0.20.0
-        version: 0.20.0
       typescript:
         specifier: ^4.5.5
         version: 4.9.5
@@ -248,7 +252,7 @@ importers:
         version: 0.34.6(jsdom@21.1.1)
 
   components/topbar:
-    devDependencies:
+    dependencies:
       '@fluentui/react-components':
         specifier: ^9.34.2
         version: 9.34.2(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0)
@@ -261,6 +265,10 @@ importers:
       '@griffel/react':
         specifier: ^1.5.16
         version: 1.5.16(react@17.0.2)
+      scheduler:
+        specifier: ^0.20.0
+        version: 0.20.0
+    devDependencies:
       '@testing-library/jest-dom':
         specifier: ^5.16.5
         version: 5.16.5
@@ -288,9 +296,6 @@ importers:
       react-dom:
         specifier: ^17.0.2
         version: 17.0.2(react@17.0.2)
-      scheduler:
-        specifier: ^0.20.0
-        version: 0.20.0
       typescript:
         specifier: ^4.5.5
         version: 4.9.5
@@ -387,10 +392,11 @@ importers:
         version: 4.9.5
 
   icons:
-    devDependencies:
+    dependencies:
       '@griffel/react':
         specifier: ^1.5.16
         version: 1.5.16(react@18.2.0)
+    devDependencies:
       '@svgr/core':
         specifier: ^5.5.0
         version: 5.5.0
@@ -426,10 +432,11 @@ importers:
         version: 14.2.3
 
   styles:
-    devDependencies:
+    dependencies:
       '@fluentui/react-components':
         specifier: ^9.34.2
         version: 9.34.2(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
+    devDependencies:
       '@types/react':
         specifier: ^18.2.24
         version: 18.2.24
@@ -444,10 +451,14 @@ importers:
         version: 4.9.5
 
   theme:
-    devDependencies:
+    dependencies:
       '@fluentui/react-components':
         specifier: ^9.34.2
         version: 9.34.2(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
+      scheduler:
+        specifier: ^0.20.0
+        version: 0.20.0
+    devDependencies:
       '@types/node':
         specifier: ^18.0.0
         version: 18.15.11
@@ -466,9 +477,6 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
-      scheduler:
-        specifier: ^0.20.0
-        version: 0.20.0
       style-dictionary:
         specifier: ^3.8.0
         version: 3.8.0
@@ -851,6 +859,7 @@ packages:
 
   /@emotion/hash@0.9.1:
     resolution: {integrity: sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==}
+    dev: false
 
   /@esbuild/android-arm@0.15.18:
     resolution: {integrity: sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==}
@@ -926,25 +935,30 @@ packages:
     resolution: {integrity: sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==}
     dependencies:
       '@floating-ui/utils': 0.1.6
+    dev: false
 
   /@floating-ui/dom@1.5.3:
     resolution: {integrity: sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==}
     dependencies:
       '@floating-ui/core': 1.5.0
       '@floating-ui/utils': 0.1.6
+    dev: false
 
   /@floating-ui/utils@0.1.6:
     resolution: {integrity: sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==}
+    dev: false
 
   /@fluentui/keyboard-keys@9.0.6:
     resolution: {integrity: sha512-WvJrCKvt8Om04S+IwypeJ3FG2tP2TSNFMSMYouDdeKspKD1EmQyQybs7YA9+Fh98X5ERF14zBCurgtNjpDH6gQ==}
     dependencies:
       '@swc/helpers': 0.5.2
+    dev: false
 
   /@fluentui/priority-overflow@9.1.7:
     resolution: {integrity: sha512-+SzSmEr5+/n7c1vmqAb2Ykk3Z5Dh2yqIl/dDbQjuiSaQzZHjr/b59A06x6t/JXKWFH8g4yG6A2LpSeLIbRBP9Q==}
     dependencies:
       '@swc/helpers': 0.5.2
+    dev: false
 
   /@fluentui/react-accordion@9.3.20(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-bbSufbu77s7awrTFoQDI/UuMC/+BNBPS9fR8yJj0LYNb36XrONYGUawK8RuXaVECDiYz0gS3+3srtJauhuhcvw==}
@@ -970,6 +984,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       scheduler: 0.20.0
+    dev: false
 
   /@fluentui/react-accordion@9.3.20(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-bbSufbu77s7awrTFoQDI/UuMC/+BNBPS9fR8yJj0LYNb36XrONYGUawK8RuXaVECDiYz0gS3+3srtJauhuhcvw==}
@@ -995,7 +1010,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scheduler: 0.20.0
-    dev: true
+    dev: false
 
   /@fluentui/react-accordion@9.3.20(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-bbSufbu77s7awrTFoQDI/UuMC/+BNBPS9fR8yJj0LYNb36XrONYGUawK8RuXaVECDiYz0gS3+3srtJauhuhcvw==}
@@ -1021,7 +1036,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scheduler: 0.20.0
-    dev: true
+    dev: false
 
   /@fluentui/react-alert@9.0.0-beta.84(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-5UAGeAbrWQQrDXwgeJHEk975OxTBuujkmKZ37GfY+EJftYqDAYI5i7D72tFXbk4rcC2y72Cur9yqNBvalI30YQ==}
@@ -1046,6 +1061,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - scheduler
+    dev: false
 
   /@fluentui/react-alert@9.0.0-beta.84(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-5UAGeAbrWQQrDXwgeJHEk975OxTBuujkmKZ37GfY+EJftYqDAYI5i7D72tFXbk4rcC2y72Cur9yqNBvalI30YQ==}
@@ -1070,7 +1086,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-alert@9.0.0-beta.84(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-5UAGeAbrWQQrDXwgeJHEk975OxTBuujkmKZ37GfY+EJftYqDAYI5i7D72tFXbk4rcC2y72Cur9yqNBvalI30YQ==}
@@ -1095,7 +1111,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-aria@9.3.41(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-ZuICvlG80X7Xh75jvrlBBJQGcZrAL72bmnMjZK4tVFz9MPEJQHLLIc+CtsifQ3CW7KKLJz3GwgJLQiMGDDQF2A==}
@@ -1112,6 +1128,7 @@ packages:
       '@types/react-dom': 17.0.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   /@fluentui/react-aria@9.3.41(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-ZuICvlG80X7Xh75jvrlBBJQGcZrAL72bmnMjZK4tVFz9MPEJQHLLIc+CtsifQ3CW7KKLJz3GwgJLQiMGDDQF2A==}
@@ -1128,7 +1145,7 @@ packages:
       '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-aria@9.3.41(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-ZuICvlG80X7Xh75jvrlBBJQGcZrAL72bmnMjZK4tVFz9MPEJQHLLIc+CtsifQ3CW7KKLJz3GwgJLQiMGDDQF2A==}
@@ -1145,7 +1162,7 @@ packages:
       '@types/react-dom': 18.2.9
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-avatar@9.5.38(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-0TtjqxX8fkAzVLT7VbOF+MAr20ciRxqTUasD4KLTiiOY5MB0h4+XbKQYnwhQqb62wP9T0yeUnNwt0C/IWEnP+A==}
@@ -1173,6 +1190,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       scheduler: 0.20.0
+    dev: false
 
   /@fluentui/react-avatar@9.5.38(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-0TtjqxX8fkAzVLT7VbOF+MAr20ciRxqTUasD4KLTiiOY5MB0h4+XbKQYnwhQqb62wP9T0yeUnNwt0C/IWEnP+A==}
@@ -1200,7 +1218,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scheduler: 0.20.0
-    dev: true
+    dev: false
 
   /@fluentui/react-avatar@9.5.38(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-0TtjqxX8fkAzVLT7VbOF+MAr20ciRxqTUasD4KLTiiOY5MB0h4+XbKQYnwhQqb62wP9T0yeUnNwt0C/IWEnP+A==}
@@ -1228,7 +1246,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scheduler: 0.20.0
-    dev: true
+    dev: false
 
   /@fluentui/react-badge@9.2.7(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-bXx4EffQn1D0/RgH13G33MiAD2aMp0qRLlz8RuPwy7fKR9XX/VXc01DyZI8mABnXPht+TPw8LokKL19W8XGMsg==}
@@ -1249,6 +1267,7 @@ packages:
       '@types/react-dom': 17.0.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   /@fluentui/react-badge@9.2.7(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-bXx4EffQn1D0/RgH13G33MiAD2aMp0qRLlz8RuPwy7fKR9XX/VXc01DyZI8mABnXPht+TPw8LokKL19W8XGMsg==}
@@ -1269,7 +1288,7 @@ packages:
       '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-badge@9.2.7(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-bXx4EffQn1D0/RgH13G33MiAD2aMp0qRLlz8RuPwy7fKR9XX/VXc01DyZI8mABnXPht+TPw8LokKL19W8XGMsg==}
@@ -1290,7 +1309,7 @@ packages:
       '@types/react-dom': 18.2.9
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-button@9.3.47(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-fGaqg/7oeeM6HR8KMqkhwVOkabByqdcK4E5baHO4YhXA9ST45Mujihruteuey78OReJP4CbH8ktli4ySSr6gHQ==}
@@ -1314,6 +1333,7 @@ packages:
       '@types/react-dom': 17.0.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   /@fluentui/react-button@9.3.47(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-fGaqg/7oeeM6HR8KMqkhwVOkabByqdcK4E5baHO4YhXA9ST45Mujihruteuey78OReJP4CbH8ktli4ySSr6gHQ==}
@@ -1337,7 +1357,7 @@ packages:
       '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-button@9.3.47(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-fGaqg/7oeeM6HR8KMqkhwVOkabByqdcK4E5baHO4YhXA9ST45Mujihruteuey78OReJP4CbH8ktli4ySSr6gHQ==}
@@ -1361,7 +1381,7 @@ packages:
       '@types/react-dom': 18.2.9
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-card@9.0.46(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-JzD2tnPJ65KmxEAKk8ckTXv6kpxggflCooNBAp6WRROTP9FGy5xE9TD+VIJSS48l+NKwiHXOqyJpIl+estxRdA==}
@@ -1382,6 +1402,7 @@ packages:
       '@types/react-dom': 17.0.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   /@fluentui/react-card@9.0.46(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-JzD2tnPJ65KmxEAKk8ckTXv6kpxggflCooNBAp6WRROTP9FGy5xE9TD+VIJSS48l+NKwiHXOqyJpIl+estxRdA==}
@@ -1402,7 +1423,7 @@ packages:
       '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-card@9.0.46(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-JzD2tnPJ65KmxEAKk8ckTXv6kpxggflCooNBAp6WRROTP9FGy5xE9TD+VIJSS48l+NKwiHXOqyJpIl+estxRdA==}
@@ -1423,7 +1444,7 @@ packages:
       '@types/react-dom': 18.2.9
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-checkbox@9.1.48(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-eURLwdj781wEEvbWmm+9nrv3NK01dYULwcL/FUDNvTgUcdpViaYclMJ6KPMAzkg079Ho2/vkyTDAx54VMVINGw==}
@@ -1449,6 +1470,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - scheduler
+    dev: false
 
   /@fluentui/react-checkbox@9.1.48(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-eURLwdj781wEEvbWmm+9nrv3NK01dYULwcL/FUDNvTgUcdpViaYclMJ6KPMAzkg079Ho2/vkyTDAx54VMVINGw==}
@@ -1474,7 +1496,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-checkbox@9.1.48(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-eURLwdj781wEEvbWmm+9nrv3NK01dYULwcL/FUDNvTgUcdpViaYclMJ6KPMAzkg079Ho2/vkyTDAx54VMVINGw==}
@@ -1500,7 +1522,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-combobox@9.5.22(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-KogtGNzNhUBa5ewE0w8+gN/iLHFQLvLpceDkkrUUT71+YxsZLMa3j/PPSJGc8vUNd0RmsmJ3KQSJrQMFDgIdjw==}
@@ -1528,6 +1550,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       scheduler: 0.20.0
+    dev: false
 
   /@fluentui/react-combobox@9.5.22(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-KogtGNzNhUBa5ewE0w8+gN/iLHFQLvLpceDkkrUUT71+YxsZLMa3j/PPSJGc8vUNd0RmsmJ3KQSJrQMFDgIdjw==}
@@ -1555,7 +1578,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scheduler: 0.20.0
-    dev: true
+    dev: false
 
   /@fluentui/react-combobox@9.5.22(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-KogtGNzNhUBa5ewE0w8+gN/iLHFQLvLpceDkkrUUT71+YxsZLMa3j/PPSJGc8vUNd0RmsmJ3KQSJrQMFDgIdjw==}
@@ -1583,7 +1606,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scheduler: 0.20.0
-    dev: true
+    dev: false
 
   /@fluentui/react-components@9.34.2(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-8KrEd/g+juLTFSbhHbsO1YED4emG2+yvvvsDum4q8jN5IoSA6LkxsOMXDUY52S3eoSMTrpK+B7HShZWpaB+jpQ==}
@@ -1647,6 +1670,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       scheduler: 0.20.0
+    dev: false
 
   /@fluentui/react-components@9.34.2(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-8KrEd/g+juLTFSbhHbsO1YED4emG2+yvvvsDum4q8jN5IoSA6LkxsOMXDUY52S3eoSMTrpK+B7HShZWpaB+jpQ==}
@@ -1710,7 +1734,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scheduler: 0.20.0
-    dev: true
+    dev: false
 
   /@fluentui/react-components@9.34.2(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-8KrEd/g+juLTFSbhHbsO1YED4emG2+yvvvsDum4q8jN5IoSA6LkxsOMXDUY52S3eoSMTrpK+B7HShZWpaB+jpQ==}
@@ -1774,7 +1798,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scheduler: 0.20.0
-    dev: true
+    dev: false
 
   /@fluentui/react-context-selector@9.1.39(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-rZJM2XeeHZt7wv0aQTdSIX+KSGqoOvMv1CBfRRuWYcZHjixLPxQn3yDyo0tvuJoT3CzIrrehU5PSzEIn3v6dww==}
@@ -1792,6 +1816,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       scheduler: 0.20.0
+    dev: false
 
   /@fluentui/react-context-selector@9.1.39(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-rZJM2XeeHZt7wv0aQTdSIX+KSGqoOvMv1CBfRRuWYcZHjixLPxQn3yDyo0tvuJoT3CzIrrehU5PSzEIn3v6dww==}
@@ -1809,7 +1834,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scheduler: 0.20.0
-    dev: true
+    dev: false
 
   /@fluentui/react-context-selector@9.1.39(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-rZJM2XeeHZt7wv0aQTdSIX+KSGqoOvMv1CBfRRuWYcZHjixLPxQn3yDyo0tvuJoT3CzIrrehU5PSzEIn3v6dww==}
@@ -1827,7 +1852,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scheduler: 0.20.0
-    dev: true
+    dev: false
 
   /@fluentui/react-dialog@9.7.7(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-A/JJrRdolMBsoBaOHton1ljjLiix4vHe+QX6t9tCdaBmwQiVQVVRW45+kochpYXXz+ydWcGq+wGENmN1xNdGXA==}
@@ -1855,6 +1880,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - scheduler
+    dev: false
 
   /@fluentui/react-dialog@9.7.7(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-A/JJrRdolMBsoBaOHton1ljjLiix4vHe+QX6t9tCdaBmwQiVQVVRW45+kochpYXXz+ydWcGq+wGENmN1xNdGXA==}
@@ -1882,7 +1908,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-dialog@9.7.7(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-A/JJrRdolMBsoBaOHton1ljjLiix4vHe+QX6t9tCdaBmwQiVQVVRW45+kochpYXXz+ydWcGq+wGENmN1xNdGXA==}
@@ -1910,7 +1936,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-divider@9.2.43(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-UmH8ugXqHDOQPQtfzN/4QS9HjagvbyBIdNDr/rhExILEZKoOwSFVAPUoQUEtNKV7MsM56+7LXIdc969ogHIexg==}
@@ -1930,6 +1956,7 @@ packages:
       '@types/react-dom': 17.0.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   /@fluentui/react-divider@9.2.43(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-UmH8ugXqHDOQPQtfzN/4QS9HjagvbyBIdNDr/rhExILEZKoOwSFVAPUoQUEtNKV7MsM56+7LXIdc969ogHIexg==}
@@ -1949,7 +1976,7 @@ packages:
       '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-divider@9.2.43(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-UmH8ugXqHDOQPQtfzN/4QS9HjagvbyBIdNDr/rhExILEZKoOwSFVAPUoQUEtNKV7MsM56+7LXIdc969ogHIexg==}
@@ -1969,7 +1996,7 @@ packages:
       '@types/react-dom': 18.2.9
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-drawer@9.0.0-beta.33(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-HfoDsQs+0AKvvP+Xv8vFYteJfJI8reKZuYgNuLMvHFm9Khy4HUPqfzkEOsIgKr5WPbMcuQPmRqA3QRWrqiZidw==}
@@ -1994,6 +2021,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - scheduler
+    dev: false
 
   /@fluentui/react-drawer@9.0.0-beta.33(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-HfoDsQs+0AKvvP+Xv8vFYteJfJI8reKZuYgNuLMvHFm9Khy4HUPqfzkEOsIgKr5WPbMcuQPmRqA3QRWrqiZidw==}
@@ -2018,7 +2046,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-drawer@9.0.0-beta.33(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-HfoDsQs+0AKvvP+Xv8vFYteJfJI8reKZuYgNuLMvHFm9Khy4HUPqfzkEOsIgKr5WPbMcuQPmRqA3QRWrqiZidw==}
@@ -2043,7 +2071,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-field@9.1.35(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-uJQwm0WxNAHO20b/+LsiAb9tdo00+4spLUaFVYSqrUUBgLVMLm+HIOYSO6jyGOOg4qjEhEELZeJehNxuu1vPjw==}
@@ -2067,6 +2095,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - scheduler
+    dev: false
 
   /@fluentui/react-field@9.1.35(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-uJQwm0WxNAHO20b/+LsiAb9tdo00+4spLUaFVYSqrUUBgLVMLm+HIOYSO6jyGOOg4qjEhEELZeJehNxuu1vPjw==}
@@ -2090,7 +2119,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-field@9.1.35(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-uJQwm0WxNAHO20b/+LsiAb9tdo00+4spLUaFVYSqrUUBgLVMLm+HIOYSO6jyGOOg4qjEhEELZeJehNxuu1vPjw==}
@@ -2114,7 +2143,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-icons@2.0.219(react@17.0.2):
     resolution: {integrity: sha512-KYOtNfB7Zlk/zbs3LfFQWD1q2cUs62tTC2LulAsPjSEbWwzrDcAGrTxtSnFvohjkHqM4kiY1a10DC9QlLCLLZw==}
@@ -2124,6 +2153,7 @@ packages:
       '@griffel/react': 1.5.16(react@17.0.2)
       react: 17.0.2
       tslib: 2.6.2
+    dev: false
 
   /@fluentui/react-icons@2.0.219(react@18.2.0):
     resolution: {integrity: sha512-KYOtNfB7Zlk/zbs3LfFQWD1q2cUs62tTC2LulAsPjSEbWwzrDcAGrTxtSnFvohjkHqM4kiY1a10DC9QlLCLLZw==}
@@ -2133,7 +2163,7 @@ packages:
       '@griffel/react': 1.5.16(react@18.2.0)
       react: 18.2.0
       tslib: 2.6.2
-    dev: true
+    dev: false
 
   /@fluentui/react-image@9.1.40(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-FPjaLpz2mhf0WHm9mC/TvUskiD6MHCQw2T2Y5jwtSVRiNHxHmY1nd09mJWOhDH2jwCK3azmwhQk+/fTI78vAww==}
@@ -2153,6 +2183,7 @@ packages:
       '@types/react-dom': 17.0.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   /@fluentui/react-image@9.1.40(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-FPjaLpz2mhf0WHm9mC/TvUskiD6MHCQw2T2Y5jwtSVRiNHxHmY1nd09mJWOhDH2jwCK3azmwhQk+/fTI78vAww==}
@@ -2172,7 +2203,7 @@ packages:
       '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-image@9.1.40(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-FPjaLpz2mhf0WHm9mC/TvUskiD6MHCQw2T2Y5jwtSVRiNHxHmY1nd09mJWOhDH2jwCK3azmwhQk+/fTI78vAww==}
@@ -2192,7 +2223,7 @@ packages:
       '@types/react-dom': 18.2.9
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-infobutton@9.0.0-beta.68(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-j2MTzmxPjKdo985dARYFgqhDXRIE02Y041DEvjjeZ6zWsCqqkfMrtYHRayM4wUypBDIez1D0vDCBuVeMscaldg==}
@@ -2218,6 +2249,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - scheduler
+    dev: false
 
   /@fluentui/react-infobutton@9.0.0-beta.68(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-j2MTzmxPjKdo985dARYFgqhDXRIE02Y041DEvjjeZ6zWsCqqkfMrtYHRayM4wUypBDIez1D0vDCBuVeMscaldg==}
@@ -2243,7 +2275,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-infobutton@9.0.0-beta.68(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-j2MTzmxPjKdo985dARYFgqhDXRIE02Y041DEvjjeZ6zWsCqqkfMrtYHRayM4wUypBDIez1D0vDCBuVeMscaldg==}
@@ -2269,7 +2301,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-input@9.4.45(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-MF+Rfbm0pFQO1dbjcoJ+b2u21Lwetqysmn3gDSORaVQSJJAowj6bGGYNdDo/Ji4i+am+a202dw+04UMYi5Db1w==}
@@ -2292,6 +2324,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - scheduler
+    dev: false
 
   /@fluentui/react-input@9.4.45(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-MF+Rfbm0pFQO1dbjcoJ+b2u21Lwetqysmn3gDSORaVQSJJAowj6bGGYNdDo/Ji4i+am+a202dw+04UMYi5Db1w==}
@@ -2314,7 +2347,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-input@9.4.45(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-MF+Rfbm0pFQO1dbjcoJ+b2u21Lwetqysmn3gDSORaVQSJJAowj6bGGYNdDo/Ji4i+am+a202dw+04UMYi5Db1w==}
@@ -2337,7 +2370,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-jsx-runtime@9.0.15(@types/react@17.0.67)(react@17.0.2):
     resolution: {integrity: sha512-5CyzxTm3PCbJ2S3iiQi1uZRkIrIc+o0GsnmLohQKW20I8Shv8Rhh9yf7x5k81AJw2raZho/G7yQ1uNmns58YVA==}
@@ -2349,6 +2382,7 @@ packages:
       '@swc/helpers': 0.5.2
       '@types/react': 17.0.67
       react: 17.0.2
+    dev: false
 
   /@fluentui/react-jsx-runtime@9.0.15(@types/react@18.2.24)(react@18.2.0):
     resolution: {integrity: sha512-5CyzxTm3PCbJ2S3iiQi1uZRkIrIc+o0GsnmLohQKW20I8Shv8Rhh9yf7x5k81AJw2raZho/G7yQ1uNmns58YVA==}
@@ -2360,7 +2394,7 @@ packages:
       '@swc/helpers': 0.5.2
       '@types/react': 18.2.24
       react: 18.2.0
-    dev: true
+    dev: false
 
   /@fluentui/react-label@9.1.43(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-HR69f/QHl8d1vnot4oZmqzE/z9zYvWkxTjZxb7M5ah+FcnTyIwdK5T2ZeymPDjy7aSkMp79ZKQiSMI0gwq8GHw==}
@@ -2380,6 +2414,7 @@ packages:
       '@types/react-dom': 17.0.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   /@fluentui/react-label@9.1.43(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-HR69f/QHl8d1vnot4oZmqzE/z9zYvWkxTjZxb7M5ah+FcnTyIwdK5T2ZeymPDjy7aSkMp79ZKQiSMI0gwq8GHw==}
@@ -2399,7 +2434,7 @@ packages:
       '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-label@9.1.43(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-HR69f/QHl8d1vnot4oZmqzE/z9zYvWkxTjZxb7M5ah+FcnTyIwdK5T2ZeymPDjy7aSkMp79ZKQiSMI0gwq8GHw==}
@@ -2419,7 +2454,7 @@ packages:
       '@types/react-dom': 18.2.9
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-link@9.1.26(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-lDbaBvV2ePY6/8FKJxhjXSabFWYr3Amurs1+Dy6+6SAhrhFPJPlMDzrrGTfDQfVc4Ke7rCvlTz48JS8PR5rsiQ==}
@@ -2441,6 +2476,7 @@ packages:
       '@types/react-dom': 17.0.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   /@fluentui/react-link@9.1.26(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-lDbaBvV2ePY6/8FKJxhjXSabFWYr3Amurs1+Dy6+6SAhrhFPJPlMDzrrGTfDQfVc4Ke7rCvlTz48JS8PR5rsiQ==}
@@ -2462,7 +2498,7 @@ packages:
       '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-link@9.1.26(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-lDbaBvV2ePY6/8FKJxhjXSabFWYr3Amurs1+Dy6+6SAhrhFPJPlMDzrrGTfDQfVc4Ke7rCvlTz48JS8PR5rsiQ==}
@@ -2484,7 +2520,7 @@ packages:
       '@types/react-dom': 18.2.9
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-menu@9.12.24(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-P+Wpx+ghMLjzfi0yU/cE1a+Lmt9e3MEgbvo0+6erN+ecocymS6S3NHywYGy4xGt8eXW8w+lD+oCXKU+V3aXfgg==}
@@ -2513,6 +2549,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       scheduler: 0.20.0
+    dev: false
 
   /@fluentui/react-menu@9.12.24(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-P+Wpx+ghMLjzfi0yU/cE1a+Lmt9e3MEgbvo0+6erN+ecocymS6S3NHywYGy4xGt8eXW8w+lD+oCXKU+V3aXfgg==}
@@ -2541,7 +2578,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scheduler: 0.20.0
-    dev: true
+    dev: false
 
   /@fluentui/react-menu@9.12.24(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-P+Wpx+ghMLjzfi0yU/cE1a+Lmt9e3MEgbvo0+6erN+ecocymS6S3NHywYGy4xGt8eXW8w+lD+oCXKU+V3aXfgg==}
@@ -2570,7 +2607,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scheduler: 0.20.0
-    dev: true
+    dev: false
 
   /@fluentui/react-motion-preview@0.3.1(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-7EhCwUHKj3W2QoFy08RuKYXcSBKpet4jcegoC8BRQWwS03a/005hy+5oGF2Uii69/l2p59ZYPy994OLAwOCqbA==}
@@ -2590,6 +2627,7 @@ packages:
       '@types/react-dom': 17.0.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   /@fluentui/react-motion-preview@0.3.1(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-7EhCwUHKj3W2QoFy08RuKYXcSBKpet4jcegoC8BRQWwS03a/005hy+5oGF2Uii69/l2p59ZYPy994OLAwOCqbA==}
@@ -2609,7 +2647,7 @@ packages:
       '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-motion-preview@0.3.1(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-7EhCwUHKj3W2QoFy08RuKYXcSBKpet4jcegoC8BRQWwS03a/005hy+5oGF2Uii69/l2p59ZYPy994OLAwOCqbA==}
@@ -2629,7 +2667,7 @@ packages:
       '@types/react-dom': 18.2.9
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-overflow@9.0.38(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-vrofilg4SFsDIS4sSaGRmQxZdIFNAKoaYGIYUym7Zf5JzrrfUyEUxhxefeP9EFhDXqhtn0kyLhJEDe+1DAQwdQ==}
@@ -2651,6 +2689,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       scheduler: 0.20.0
+    dev: false
 
   /@fluentui/react-overflow@9.0.38(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-vrofilg4SFsDIS4sSaGRmQxZdIFNAKoaYGIYUym7Zf5JzrrfUyEUxhxefeP9EFhDXqhtn0kyLhJEDe+1DAQwdQ==}
@@ -2672,7 +2711,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scheduler: 0.20.0
-    dev: true
+    dev: false
 
   /@fluentui/react-overflow@9.0.38(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-vrofilg4SFsDIS4sSaGRmQxZdIFNAKoaYGIYUym7Zf5JzrrfUyEUxhxefeP9EFhDXqhtn0kyLhJEDe+1DAQwdQ==}
@@ -2694,7 +2733,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scheduler: 0.20.0
-    dev: true
+    dev: false
 
   /@fluentui/react-persona@9.2.48(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-QPTYF0FuXV12+H85GqbTUPcD+ArvMG6NKL7m/NKj6aLaEZedk1r4AeZ55CC3/xaaWwvVWQcN/qZcoLAkLVEq3w==}
@@ -2718,6 +2757,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - scheduler
+    dev: false
 
   /@fluentui/react-persona@9.2.48(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-QPTYF0FuXV12+H85GqbTUPcD+ArvMG6NKL7m/NKj6aLaEZedk1r4AeZ55CC3/xaaWwvVWQcN/qZcoLAkLVEq3w==}
@@ -2741,7 +2781,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-persona@9.2.48(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-QPTYF0FuXV12+H85GqbTUPcD+ArvMG6NKL7m/NKj6aLaEZedk1r4AeZ55CC3/xaaWwvVWQcN/qZcoLAkLVEq3w==}
@@ -2765,7 +2805,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-popover@9.8.13(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-Pa4i2yw6fUMut5ySrczTAJc55/V2lkqOtP+14c1toIr6QS6qEKxxnm8uONVOVIblDV4atlUVJSpxGclAOdEM6w==}
@@ -2793,6 +2833,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       scheduler: 0.20.0
+    dev: false
 
   /@fluentui/react-popover@9.8.13(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-Pa4i2yw6fUMut5ySrczTAJc55/V2lkqOtP+14c1toIr6QS6qEKxxnm8uONVOVIblDV4atlUVJSpxGclAOdEM6w==}
@@ -2820,7 +2861,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scheduler: 0.20.0
-    dev: true
+    dev: false
 
   /@fluentui/react-popover@9.8.13(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-Pa4i2yw6fUMut5ySrczTAJc55/V2lkqOtP+14c1toIr6QS6qEKxxnm8uONVOVIblDV4atlUVJSpxGclAOdEM6w==}
@@ -2848,7 +2889,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scheduler: 0.20.0
-    dev: true
+    dev: false
 
   /@fluentui/react-portal@9.3.22(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-Q+/mlRV80IcWv/ELz0yy+SMfGF351xUWYWShZjdmyZ4rVbqG19Qi4lj+6EbLG1bzWn7pkMsrSClMB3ATp0fPBw==}
@@ -2868,6 +2909,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       use-disposable: 1.0.2(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)
+    dev: false
 
   /@fluentui/react-portal@9.3.22(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-Q+/mlRV80IcWv/ELz0yy+SMfGF351xUWYWShZjdmyZ4rVbqG19Qi4lj+6EbLG1bzWn7pkMsrSClMB3ATp0fPBw==}
@@ -2887,7 +2929,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       use-disposable: 1.0.2(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-portal@9.3.22(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-Q+/mlRV80IcWv/ELz0yy+SMfGF351xUWYWShZjdmyZ4rVbqG19Qi4lj+6EbLG1bzWn7pkMsrSClMB3ATp0fPBw==}
@@ -2907,7 +2949,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       use-disposable: 1.0.2(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-positioning@9.9.19(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-wlXEBmXMTNZ60dfaiMbfwdYFDNLlxJxVILDbJ48icoccHdM7SqkZlJlGNzMNH4hj5KEasa5CrEitLGvv1iWtQw==}
@@ -2927,6 +2969,7 @@ packages:
       '@types/react-dom': 17.0.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   /@fluentui/react-positioning@9.9.19(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-wlXEBmXMTNZ60dfaiMbfwdYFDNLlxJxVILDbJ48icoccHdM7SqkZlJlGNzMNH4hj5KEasa5CrEitLGvv1iWtQw==}
@@ -2946,7 +2989,7 @@ packages:
       '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-positioning@9.9.19(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-wlXEBmXMTNZ60dfaiMbfwdYFDNLlxJxVILDbJ48icoccHdM7SqkZlJlGNzMNH4hj5KEasa5CrEitLGvv1iWtQw==}
@@ -2966,7 +3009,7 @@ packages:
       '@types/react-dom': 18.2.9
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-progress@9.1.45(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-AcyNEHgt5iZwVH6gH/0SBugJ0S0O4Yd0VWAR1rgVKglVj+3NqEuLPtXwId2MSx7qvWHng5Xp5vtDjScV5Yy6PQ==}
@@ -2989,6 +3032,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - scheduler
+    dev: false
 
   /@fluentui/react-progress@9.1.45(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-AcyNEHgt5iZwVH6gH/0SBugJ0S0O4Yd0VWAR1rgVKglVj+3NqEuLPtXwId2MSx7qvWHng5Xp5vtDjScV5Yy6PQ==}
@@ -3011,7 +3055,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-progress@9.1.45(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-AcyNEHgt5iZwVH6gH/0SBugJ0S0O4Yd0VWAR1rgVKglVj+3NqEuLPtXwId2MSx7qvWHng5Xp5vtDjScV5Yy6PQ==}
@@ -3034,7 +3078,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-provider@9.10.5(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-SxIT1qCoN0orlZTxpraMG/jmRUr5u91BYD4LdYWolJZFvgdRG99wOOp8E830/ZiX9qZG2Y3SaKTr3mfdFMiAww==}
@@ -3057,6 +3101,7 @@ packages:
       '@types/react-dom': 17.0.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   /@fluentui/react-provider@9.10.5(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-SxIT1qCoN0orlZTxpraMG/jmRUr5u91BYD4LdYWolJZFvgdRG99wOOp8E830/ZiX9qZG2Y3SaKTr3mfdFMiAww==}
@@ -3079,7 +3124,7 @@ packages:
       '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-provider@9.10.5(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-SxIT1qCoN0orlZTxpraMG/jmRUr5u91BYD4LdYWolJZFvgdRG99wOOp8E830/ZiX9qZG2Y3SaKTr3mfdFMiAww==}
@@ -3102,7 +3147,7 @@ packages:
       '@types/react-dom': 18.2.9
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-radio@9.1.48(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-iqle5Y0EoqtqdwKUUy2Kab4wLXp3YH9hiBv/bRm5ZlbNKeNiA4+JgxgTPWqnCynAKhk2oPtfopmvgUz9dxT77g==}
@@ -3128,6 +3173,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       scheduler: 0.20.0
+    dev: false
 
   /@fluentui/react-radio@9.1.48(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-iqle5Y0EoqtqdwKUUy2Kab4wLXp3YH9hiBv/bRm5ZlbNKeNiA4+JgxgTPWqnCynAKhk2oPtfopmvgUz9dxT77g==}
@@ -3153,7 +3199,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scheduler: 0.20.0
-    dev: true
+    dev: false
 
   /@fluentui/react-radio@9.1.48(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-iqle5Y0EoqtqdwKUUy2Kab4wLXp3YH9hiBv/bRm5ZlbNKeNiA4+JgxgTPWqnCynAKhk2oPtfopmvgUz9dxT77g==}
@@ -3179,7 +3225,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scheduler: 0.20.0
-    dev: true
+    dev: false
 
   /@fluentui/react-select@9.1.45(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-viyw7+KgJJ3C2eT2zEVwtUZbagaNBd2m13CY170PyS0hB0ICZ0ImEqK/OuBrm9jhN+HpFM5JFHqho7w9Z0v8Tw==}
@@ -3203,6 +3249,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - scheduler
+    dev: false
 
   /@fluentui/react-select@9.1.45(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-viyw7+KgJJ3C2eT2zEVwtUZbagaNBd2m13CY170PyS0hB0ICZ0ImEqK/OuBrm9jhN+HpFM5JFHqho7w9Z0v8Tw==}
@@ -3226,7 +3273,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-select@9.1.45(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-viyw7+KgJJ3C2eT2zEVwtUZbagaNBd2m13CY170PyS0hB0ICZ0ImEqK/OuBrm9jhN+HpFM5JFHqho7w9Z0v8Tw==}
@@ -3250,7 +3297,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-shared-contexts@9.10.0(@types/react@17.0.67)(react@17.0.2):
     resolution: {integrity: sha512-2ubHqWnnd2VX82wAuGV0VVOXuQMQPz3x+8cgcGDI+z0lGrBF679N8W55QuEisvnDojoe6iASxJmc311N3aRzSQ==}
@@ -3262,6 +3309,7 @@ packages:
       '@swc/helpers': 0.5.2
       '@types/react': 17.0.67
       react: 17.0.2
+    dev: false
 
   /@fluentui/react-shared-contexts@9.10.0(@types/react@18.2.24)(react@18.2.0):
     resolution: {integrity: sha512-2ubHqWnnd2VX82wAuGV0VVOXuQMQPz3x+8cgcGDI+z0lGrBF679N8W55QuEisvnDojoe6iASxJmc311N3aRzSQ==}
@@ -3273,7 +3321,7 @@ packages:
       '@swc/helpers': 0.5.2
       '@types/react': 18.2.24
       react: 18.2.0
-    dev: true
+    dev: false
 
   /@fluentui/react-skeleton@9.0.33(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-QXIrmrkNs/cZV+I90e/kAP3xf/NNWbkGTgnO8exv/Dq+ARXp0xWahJgV6uIzupjnYq5QLp3wrAPR1et4wK+0jg==}
@@ -3296,6 +3344,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - scheduler
+    dev: false
 
   /@fluentui/react-skeleton@9.0.33(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-QXIrmrkNs/cZV+I90e/kAP3xf/NNWbkGTgnO8exv/Dq+ARXp0xWahJgV6uIzupjnYq5QLp3wrAPR1et4wK+0jg==}
@@ -3318,7 +3367,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-skeleton@9.0.33(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-QXIrmrkNs/cZV+I90e/kAP3xf/NNWbkGTgnO8exv/Dq+ARXp0xWahJgV6uIzupjnYq5QLp3wrAPR1et4wK+0jg==}
@@ -3341,7 +3390,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-slider@9.1.48(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-tFUAifIjYAb/cIPBFxRBsctBxH0gRBfC/I2bQQwsDiF7/rRpfbY2Vc50Q73PPAsTpbtRoHVeWAo+7+H9W/xPZg==}
@@ -3365,6 +3414,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - scheduler
+    dev: false
 
   /@fluentui/react-slider@9.1.48(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-tFUAifIjYAb/cIPBFxRBsctBxH0gRBfC/I2bQQwsDiF7/rRpfbY2Vc50Q73PPAsTpbtRoHVeWAo+7+H9W/xPZg==}
@@ -3388,7 +3438,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-slider@9.1.48(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-tFUAifIjYAb/cIPBFxRBsctBxH0gRBfC/I2bQQwsDiF7/rRpfbY2Vc50Q73PPAsTpbtRoHVeWAo+7+H9W/xPZg==}
@@ -3412,7 +3462,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-spinbutton@9.2.45(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-k8R9lJRX5+H+zaAjrtfSiol9jjGN7e6qtX7eHAePxkXa3vkGQmCvwaKgOhY79ht+KnmIUulyZZO7F9TucWDvlA==}
@@ -3437,6 +3487,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - scheduler
+    dev: false
 
   /@fluentui/react-spinbutton@9.2.45(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-k8R9lJRX5+H+zaAjrtfSiol9jjGN7e6qtX7eHAePxkXa3vkGQmCvwaKgOhY79ht+KnmIUulyZZO7F9TucWDvlA==}
@@ -3461,7 +3512,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-spinbutton@9.2.45(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-k8R9lJRX5+H+zaAjrtfSiol9jjGN7e6qtX7eHAePxkXa3vkGQmCvwaKgOhY79ht+KnmIUulyZZO7F9TucWDvlA==}
@@ -3486,7 +3537,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-spinner@9.3.23(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-ZcF+0VymOUfymgP6juafO0ZfQrSKB5XzLaodSZY/ulMMUqOof6IpA8id6jSt/RrfFIN9TeJLblRvjLgd4Kc/QA==}
@@ -3507,6 +3558,7 @@ packages:
       '@types/react-dom': 17.0.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   /@fluentui/react-spinner@9.3.23(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-ZcF+0VymOUfymgP6juafO0ZfQrSKB5XzLaodSZY/ulMMUqOof6IpA8id6jSt/RrfFIN9TeJLblRvjLgd4Kc/QA==}
@@ -3527,7 +3579,7 @@ packages:
       '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-spinner@9.3.23(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-ZcF+0VymOUfymgP6juafO0ZfQrSKB5XzLaodSZY/ulMMUqOof6IpA8id6jSt/RrfFIN9TeJLblRvjLgd4Kc/QA==}
@@ -3548,7 +3600,7 @@ packages:
       '@types/react-dom': 18.2.9
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-switch@9.1.48(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-VRqTNrggb0n+X2ecAT65YesXyZENf28vDfIT6yabmw4DBVBJdiMmMiZr4K/77Dey/+gBZ8+CrEUc8Y8M0Vigxw==}
@@ -3574,6 +3626,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - scheduler
+    dev: false
 
   /@fluentui/react-switch@9.1.48(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-VRqTNrggb0n+X2ecAT65YesXyZENf28vDfIT6yabmw4DBVBJdiMmMiZr4K/77Dey/+gBZ8+CrEUc8Y8M0Vigxw==}
@@ -3599,7 +3652,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-switch@9.1.48(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-VRqTNrggb0n+X2ecAT65YesXyZENf28vDfIT6yabmw4DBVBJdiMmMiZr4K/77Dey/+gBZ8+CrEUc8Y8M0Vigxw==}
@@ -3625,7 +3678,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-table@9.10.3(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-LqAKAS9fuTHuJDxcguYEUK4/FenE+yqysjSpK1Tamvd2DAh/tLNrJJ0K8KCmelz4M8WMrG3VImqsZpXUabHwPw==}
@@ -3655,6 +3708,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - scheduler
+    dev: false
 
   /@fluentui/react-table@9.10.3(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-LqAKAS9fuTHuJDxcguYEUK4/FenE+yqysjSpK1Tamvd2DAh/tLNrJJ0K8KCmelz4M8WMrG3VImqsZpXUabHwPw==}
@@ -3684,7 +3738,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-table@9.10.3(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-LqAKAS9fuTHuJDxcguYEUK4/FenE+yqysjSpK1Tamvd2DAh/tLNrJJ0K8KCmelz4M8WMrG3VImqsZpXUabHwPw==}
@@ -3714,7 +3768,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-tabs@9.3.49(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-RRlY9KML4UdfKCqrcOATcIWU4eO5ltcu2FJin3bmKTQeyZltUbtiE5ucXzKtLVqj8jxeOlco9eq9MOSlxiqbGw==}
@@ -3738,6 +3792,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       scheduler: 0.20.0
+    dev: false
 
   /@fluentui/react-tabs@9.3.49(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-RRlY9KML4UdfKCqrcOATcIWU4eO5ltcu2FJin3bmKTQeyZltUbtiE5ucXzKtLVqj8jxeOlco9eq9MOSlxiqbGw==}
@@ -3761,7 +3816,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scheduler: 0.20.0
-    dev: true
+    dev: false
 
   /@fluentui/react-tabs@9.3.49(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-RRlY9KML4UdfKCqrcOATcIWU4eO5ltcu2FJin3bmKTQeyZltUbtiE5ucXzKtLVqj8jxeOlco9eq9MOSlxiqbGw==}
@@ -3785,7 +3840,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scheduler: 0.20.0
-    dev: true
+    dev: false
 
   /@fluentui/react-tabster@9.13.5(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-MaWv5XfZcgKrEWP+hUhwa8Monl2yrrmWp3UwyX8bgUMm+AiXGpTcZqB4EeBclqhMQSAYkoyRIVsHd5RJ9qirhQ==}
@@ -3806,6 +3861,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       tabster: 4.7.3
+    dev: false
 
   /@fluentui/react-tabster@9.13.5(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-MaWv5XfZcgKrEWP+hUhwa8Monl2yrrmWp3UwyX8bgUMm+AiXGpTcZqB4EeBclqhMQSAYkoyRIVsHd5RJ9qirhQ==}
@@ -3826,7 +3882,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tabster: 4.7.3
-    dev: true
+    dev: false
 
   /@fluentui/react-tabster@9.13.5(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-MaWv5XfZcgKrEWP+hUhwa8Monl2yrrmWp3UwyX8bgUMm+AiXGpTcZqB4EeBclqhMQSAYkoyRIVsHd5RJ9qirhQ==}
@@ -3847,7 +3903,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tabster: 4.7.3
-    dev: true
+    dev: false
 
   /@fluentui/react-tags@9.0.2(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-svZ7+Yh/6hPzvsMKAE78k+UpZaQZMNXaPkbsTdWiQu/8ZREeBH1GfxHddeuU5MV0KUVuHvk1C9ooDgD1PJzFgA==}
@@ -3874,6 +3930,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - scheduler
+    dev: false
 
   /@fluentui/react-tags@9.0.2(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-svZ7+Yh/6hPzvsMKAE78k+UpZaQZMNXaPkbsTdWiQu/8ZREeBH1GfxHddeuU5MV0KUVuHvk1C9ooDgD1PJzFgA==}
@@ -3900,7 +3957,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-tags@9.0.2(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-svZ7+Yh/6hPzvsMKAE78k+UpZaQZMNXaPkbsTdWiQu/8ZREeBH1GfxHddeuU5MV0KUVuHvk1C9ooDgD1PJzFgA==}
@@ -3927,7 +3984,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-text@9.3.40(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-QzhjsfEI/tggNWPW/ne9+Sz913vq5s+nOF2nsIWKu3zFW2d7KrjdU+HlcUUcnv6+YVUcAiHtaKQpUE54dQYG3w==}
@@ -3947,6 +4004,7 @@ packages:
       '@types/react-dom': 17.0.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   /@fluentui/react-text@9.3.40(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-QzhjsfEI/tggNWPW/ne9+Sz913vq5s+nOF2nsIWKu3zFW2d7KrjdU+HlcUUcnv6+YVUcAiHtaKQpUE54dQYG3w==}
@@ -3966,7 +4024,7 @@ packages:
       '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-text@9.3.40(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-QzhjsfEI/tggNWPW/ne9+Sz913vq5s+nOF2nsIWKu3zFW2d7KrjdU+HlcUUcnv6+YVUcAiHtaKQpUE54dQYG3w==}
@@ -3986,7 +4044,7 @@ packages:
       '@types/react-dom': 18.2.9
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-textarea@9.3.45(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-qpuNpbqH+2sOxUIP4OOreD5iL+TobryiJTeRCajYCtm+ldrURyYc8ii5PZ0Q4mujgLezqpDcr6Ym1oAglOKikA==}
@@ -4009,6 +4067,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - scheduler
+    dev: false
 
   /@fluentui/react-textarea@9.3.45(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-qpuNpbqH+2sOxUIP4OOreD5iL+TobryiJTeRCajYCtm+ldrURyYc8ii5PZ0Q4mujgLezqpDcr6Ym1oAglOKikA==}
@@ -4031,7 +4090,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-textarea@9.3.45(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-qpuNpbqH+2sOxUIP4OOreD5iL+TobryiJTeRCajYCtm+ldrURyYc8ii5PZ0Q4mujgLezqpDcr6Ym1oAglOKikA==}
@@ -4054,13 +4113,14 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-theme@9.1.14:
     resolution: {integrity: sha512-Lc76jjNETV6gOFlE8b03WxcztdMhrYlj7eu6ZfRWtS6jJvyLka2BMm4ES8RyPPKmdbLnN/+BuOE6YySBs2qamg==}
     dependencies:
       '@fluentui/tokens': 1.0.0-alpha.11
       '@swc/helpers': 0.5.2
+    dev: false
 
   /@fluentui/react-toast@9.3.9(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-ydnRVG0GZfAWTfKTEGo07gtnXR5Hi+1BayMApNOguP5iioZ57eaUk64p9HGSdAY8KZs0o6ZSv3FYCHwN211arw==}
@@ -4086,6 +4146,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       react-transition-group: 4.4.5(react-dom@17.0.2)(react@17.0.2)
+    dev: false
 
   /@fluentui/react-toast@9.3.9(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-ydnRVG0GZfAWTfKTEGo07gtnXR5Hi+1BayMApNOguP5iioZ57eaUk64p9HGSdAY8KZs0o6ZSv3FYCHwN211arw==}
@@ -4111,7 +4172,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-transition-group: 4.4.5(react-dom@18.2.0)(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-toast@9.3.9(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-ydnRVG0GZfAWTfKTEGo07gtnXR5Hi+1BayMApNOguP5iioZ57eaUk64p9HGSdAY8KZs0o6ZSv3FYCHwN211arw==}
@@ -4137,7 +4198,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-transition-group: 4.4.5(react-dom@18.2.0)(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-toolbar@9.1.48(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-6THb2BIx96gzqV/W1LKYWA3kBYzWKo30USa619/yAsomneeZZyAGo5FRmZcL/K6Vckjk5NChEi5fqRSfKIy9XA==}
@@ -4164,6 +4225,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - scheduler
+    dev: false
 
   /@fluentui/react-toolbar@9.1.48(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-6THb2BIx96gzqV/W1LKYWA3kBYzWKo30USa619/yAsomneeZZyAGo5FRmZcL/K6Vckjk5NChEi5fqRSfKIy9XA==}
@@ -4190,7 +4252,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-toolbar@9.1.48(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-6THb2BIx96gzqV/W1LKYWA3kBYzWKo30USa619/yAsomneeZZyAGo5FRmZcL/K6Vckjk5NChEi5fqRSfKIy9XA==}
@@ -4217,7 +4279,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-tooltip@9.3.14(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-lpsX8Nwm5BSa8MAqYFHCxIt8HrUrrt/cFoY5PWeVyIxaIGXVqk3wby+q8WdiTm8UTUTaxBz50WTrnO4JmBds9Q==}
@@ -4240,6 +4302,7 @@ packages:
       '@types/react-dom': 17.0.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   /@fluentui/react-tooltip@9.3.14(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-lpsX8Nwm5BSa8MAqYFHCxIt8HrUrrt/cFoY5PWeVyIxaIGXVqk3wby+q8WdiTm8UTUTaxBz50WTrnO4JmBds9Q==}
@@ -4262,7 +4325,7 @@ packages:
       '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-tooltip@9.3.14(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-lpsX8Nwm5BSa8MAqYFHCxIt8HrUrrt/cFoY5PWeVyIxaIGXVqk3wby+q8WdiTm8UTUTaxBz50WTrnO4JmBds9Q==}
@@ -4285,7 +4348,7 @@ packages:
       '@types/react-dom': 18.2.9
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-tree@9.4.3(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2)(scheduler@0.20.0):
     resolution: {integrity: sha512-3bTaGrswlqz4zjjNY8p0lllGjII6bVNxSKxUMHc87XtdYnv80jFpp/ZM0YtOq/AVL0ISooxwAftwsOIsYNq73w==}
@@ -4317,6 +4380,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - scheduler
+    dev: false
 
   /@fluentui/react-tree@9.4.3(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-3bTaGrswlqz4zjjNY8p0lllGjII6bVNxSKxUMHc87XtdYnv80jFpp/ZM0YtOq/AVL0ISooxwAftwsOIsYNq73w==}
@@ -4348,7 +4412,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-tree@9.4.3(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
     resolution: {integrity: sha512-3bTaGrswlqz4zjjNY8p0lllGjII6bVNxSKxUMHc87XtdYnv80jFpp/ZM0YtOq/AVL0ISooxwAftwsOIsYNq73w==}
@@ -4380,7 +4444,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - scheduler
-    dev: true
+    dev: false
 
   /@fluentui/react-utilities@9.14.2(@types/react@17.0.67)(react@17.0.2):
     resolution: {integrity: sha512-ZuMbclGxaF+xm8Y6RD77DlXsB/gyieSlXzOeDMZxvL3XLKVJ18USakEYuTja1KhXUIW+OLKUCUpaS7XBxqv1eA==}
@@ -4392,6 +4456,7 @@ packages:
       '@swc/helpers': 0.5.2
       '@types/react': 17.0.67
       react: 17.0.2
+    dev: false
 
   /@fluentui/react-utilities@9.14.2(@types/react@18.2.24)(react@18.2.0):
     resolution: {integrity: sha512-ZuMbclGxaF+xm8Y6RD77DlXsB/gyieSlXzOeDMZxvL3XLKVJ18USakEYuTja1KhXUIW+OLKUCUpaS7XBxqv1eA==}
@@ -4403,7 +4468,7 @@ packages:
       '@swc/helpers': 0.5.2
       '@types/react': 18.2.24
       react: 18.2.0
-    dev: true
+    dev: false
 
   /@fluentui/react-virtualizer@9.0.0-alpha.49(@types/react-dom@17.0.21)(@types/react@17.0.67)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-2LYCo9T57pppFTawB8fJ0zJ35SnQjdQK71E33CoDalBAyT2S+2gdxU3bML3uWjDSyeyodDVjd3E7JBBqK/t57A==}
@@ -4421,6 +4486,7 @@ packages:
       '@types/react-dom': 17.0.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   /@fluentui/react-virtualizer@9.0.0-alpha.49(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-2LYCo9T57pppFTawB8fJ0zJ35SnQjdQK71E33CoDalBAyT2S+2gdxU3bML3uWjDSyeyodDVjd3E7JBBqK/t57A==}
@@ -4438,7 +4504,7 @@ packages:
       '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/react-virtualizer@9.0.0-alpha.49(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-2LYCo9T57pppFTawB8fJ0zJ35SnQjdQK71E33CoDalBAyT2S+2gdxU3bML3uWjDSyeyodDVjd3E7JBBqK/t57A==}
@@ -4456,12 +4522,13 @@ packages:
       '@types/react-dom': 18.2.9
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /@fluentui/tokens@1.0.0-alpha.11:
     resolution: {integrity: sha512-kHKR1/JIGcBXA0qr+MyNg8KQZL4RLJXlhaSV6yNn50rJ0kTdQHUCKbbficvNZoeQBj3x0A8/WgAbPmfppZo0Zg==}
     dependencies:
       '@swc/helpers': 0.5.2
+    dev: false
 
   /@griffel/core@1.14.3:
     resolution: {integrity: sha512-d1QqS8mP1fzF8KLLN/nhxNUHguMM9I61Ckjnn5zNUqxUlRaebnhbpa2kLDVBdIy1k22+76+NTg+pIpXXjGf+vg==}
@@ -4472,6 +4539,7 @@ packages:
       rtl-css-js: 1.16.1
       stylis: 4.3.0
       tslib: 2.6.2
+    dev: false
 
   /@griffel/react@1.5.16(react@17.0.2):
     resolution: {integrity: sha512-F4Gj1B90c7i4rLZuSmo2HaLNFHfrwr1PBsMslWDaPw6wLbiFjqubSpSEPtcq/U8Co3vva4iAX4+hD/RXSA9W8Q==}
@@ -4481,6 +4549,7 @@ packages:
       '@griffel/core': 1.14.3
       react: 17.0.2
       tslib: 2.6.2
+    dev: false
 
   /@griffel/react@1.5.16(react@18.2.0):
     resolution: {integrity: sha512-F4Gj1B90c7i4rLZuSmo2HaLNFHfrwr1PBsMslWDaPw6wLbiFjqubSpSEPtcq/U8Co3vva4iAX4+hD/RXSA9W8Q==}
@@ -4490,12 +4559,13 @@ packages:
       '@griffel/core': 1.14.3
       react: 18.2.0
       tslib: 2.6.2
-    dev: true
+    dev: false
 
   /@griffel/style-types@1.0.2:
     resolution: {integrity: sha512-ka/Tpl1WU8js88LObwB/4EvpgXzx/EEJfbHhAr4ZNt29hrQKgL93X1zSY6M/FRhMhWrGIawauWkZP6/y6w/WiQ==}
     dependencies:
       csstype: 3.1.2
+    dev: false
 
   /@humanwhocodes/config-array@0.11.8:
     resolution: {integrity: sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==}
@@ -4725,6 +4795,7 @@ packages:
     resolution: {integrity: sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==}
     dependencies:
       tslib: 2.6.2
+    dev: false
 
   /@testing-library/dom@8.20.0:
     resolution: {integrity: sha512-d9ULIT+a4EXLX3UU8FBjauG9NnsZHkHztXoIcTsOKoOw030fyjheN9svkTULjJxtYag9DZz5Jz5qkWZDPxTFwA==}
@@ -4885,13 +4956,12 @@ packages:
     resolution: {integrity: sha512-bAIvO5lN/U8sPGvs1Xm61rlRHHaq5rp5N3kp9C+NJ/Q41P8iqjkXSu0+/qu8POsjH9pNWb0OYabFez7taP7omw==}
     dependencies:
       '@types/react': 17.0.67
-    dev: true
 
   /@types/react-dom@18.2.9:
     resolution: {integrity: sha512-6nNhVzZ9joQ6F7lozrASuQKC0Kf6ArYMU+DqA2ZrUbB+d+9lC6ZLn1GxiEBI1edmAwvTULtuJ6uPZpv3XudwUg==}
     dependencies:
       '@types/react': 18.2.24
-    dev: true
+    dev: false
 
   /@types/react@17.0.67:
     resolution: {integrity: sha512-zE76EIJ0Y58Oy9yDX/9csb/NuKjt0Eq2YgWb/8Wxo91YmuLzzbyiRoaqJE9h8iDlsT7n35GdpoLomHlaB1kFbg==}
@@ -4906,7 +4976,6 @@ packages:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.3
       csstype: 3.1.2
-    dev: true
 
   /@types/scheduler@0.16.3:
     resolution: {integrity: sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==}
@@ -6114,6 +6183,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.1
       csstype: 3.1.2
+    dev: false
 
   /dom-serializer@0.2.2:
     resolution: {integrity: sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==}
@@ -7932,6 +8002,7 @@ packages:
 
   /keyborg@2.0.0:
     resolution: {integrity: sha512-RWY8nWrzRkwTQLaKyDtbTu5SOb5L4B20UzAsBHlQDFZqVY/+Mid0bQ7MVTC8vbOTrWY2xkkzj8gZF9Ua7re4xA==}
+    dev: false
 
   /levn@0.3.0:
     resolution: {integrity: sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==}
@@ -8638,7 +8709,6 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
-    dev: true
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -8691,6 +8761,7 @@ packages:
       prop-types: 15.8.1
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   /react-transition-group@4.4.5(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
@@ -8704,7 +8775,7 @@ packages:
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /react@17.0.2:
     resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
@@ -8718,7 +8789,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
-    dev: true
 
   /readable-stream@1.1.14:
     resolution: {integrity: sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==}
@@ -8946,6 +9016,7 @@ packages:
     resolution: {integrity: sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==}
     dependencies:
       '@babel/runtime': 7.23.1
+    dev: false
 
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -8999,6 +9070,7 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
+    dev: false
 
   /scheduler@0.20.2:
     resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
@@ -9010,7 +9082,6 @@ packages:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
     dependencies:
       loose-envify: 1.4.0
-    dev: true
 
   /semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
@@ -9357,6 +9428,7 @@ packages:
 
   /stylis@4.3.0:
     resolution: {integrity: sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ==}
+    dev: false
 
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -9456,6 +9528,7 @@ packages:
     dependencies:
       keyborg: 2.0.0
       tslib: 2.6.2
+    dev: false
 
   /tar@2.2.2:
     resolution: {integrity: sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==}
@@ -9798,6 +9871,7 @@ packages:
       '@types/react-dom': 17.0.21
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   /use-disposable@1.0.2(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-UMaXVlV77dWOu4GqAFNjRzHzowYKUKbJBQfCexvahrYeIz4OkUYUjna4Tjjdf92NH8Nm8J7wEfFRgTIwYjO5jg==}
@@ -9811,7 +9885,7 @@ packages:
       '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /use-disposable@1.0.2(@types/react-dom@18.2.9)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-UMaXVlV77dWOu4GqAFNjRzHzowYKUKbJBQfCexvahrYeIz4OkUYUjna4Tjjdf92NH8Nm8J7wEfFRgTIwYjO5jg==}
@@ -9825,7 +9899,7 @@ packages:
       '@types/react-dom': 18.2.9
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
+    dev: false
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}

--- a/styles/package.json
+++ b/styles/package.json
@@ -30,7 +30,6 @@
     "lint": "tsc --noEmit && eslint . --cache"
   },
   "devDependencies": {
-    "@fluentui/react-components": "^9.34.2",
     "@types/react": "^18.2.24",
     "eslint": "^7.0.0",
     "react": "^18.2.0",

--- a/theme/package.json
+++ b/theme/package.json
@@ -33,14 +33,12 @@
     "tokens:transform": "node --require ts-node/register tokens/build-ts-to-json.ts"
   },
   "devDependencies": {
-    "@fluentui/react-components": "^9.34.2",
     "@types/node": "^18.0.0",
     "@types/react": "^18.2.24",
     "@types/react-dom": "^18.2.8",
     "eslint": "^7.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "scheduler": "^0.20.0",
     "style-dictionary": "^3.8.0",
     "token-transformer": "^0.0.33",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
Removed dev-deps listed as peers since peers autoinstall in pnpm, will simplyfy maintenance of deps aswell

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
