### PR TITLE
fix: able to pick or when no default set not using custom content

### DIFF
--- a/components/topbar/src/organization-menu.tsx
+++ b/components/topbar/src/organization-menu.tsx
@@ -29,7 +29,7 @@ export const OrganizationMenu = (
 
   const currentOrganization = options?.find(({ id }) => id === value);
   const checkedValues = { org: [value] };
-  const noDropDownContent = options?.length === 1 && !customContent;
+  const noDropDownContent = (options?.length === 1 && !customContent && currentOrganization)
 
   return (
     <Menu checkedValues={checkedValues}>


### PR DESCRIPTION
Able to pick organization when none is set as default (id dont macth any opitions) and consumer provider customcontent.
