### PR TITLE
chore: add playwright system test

### DIFF
--- a/.github/workflows/verify-page.yml
+++ b/.github/workflows/verify-page.yml
@@ -1,0 +1,42 @@
+name: Verifies gh-page is up and running
+
+on:
+  push:
+    branches:
+      - main
+      - playwright-base
+  workflow_dispatch:
+
+jobs:
+  verify-gh-page:
+    runs-on: ubuntu-latest
+    steps:
+      # - name: Delay start
+      #   run: sleep 30s
+      #   shell: bash
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: |
+          corepack enable
+          corepack prepare --activate
+          pnpm install --frozen-lockfile
+
+      - name: Run Playwright tests
+        run: pnpm stest
+        working-directory: ./examples
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: examples/test-results/*
+          retention-days: 5

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -3,3 +3,6 @@ node_modules
 dist
 dist-ssr
 *.local
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/examples/package.json
+++ b/examples/package.json
@@ -17,7 +17,9 @@
     "check:unused-deps": "depcheck . --config=depcheck.yml",
     "dev": "vite",
     "lint": "tsc --noEmit && eslint . --cache",
-    "serve": "vite preview"
+    "serve": "vite preview",
+    "stest": "pnpm playwright test",
+    "stest:ui": "pnpm playwright test --ui"
   },
   "dependencies": {
     "@axiscommunications/fluent-hooks": "workspace:*",
@@ -41,6 +43,8 @@
     "vite": "^3.0.9"
   },
   "devDependencies": {
+    "@types/node": "^20.8.4",
+    "@playwright/test": "1.38.1",
     "@types/react": "^17.0.67",
     "@types/react-dom": "^17.0.21",
     "eslint": "^8.52.0",

--- a/examples/playwright.confg.base.ts
+++ b/examples/playwright.confg.base.ts
@@ -1,0 +1,42 @@
+import { Config, PlaywrightTestConfig } from "@playwright/test";
+
+type UseConfig = Config["use"];
+type Projects = Config["projects"];
+
+export const chromium = ({ flags }: { flags?: string[] } = {}): UseConfig => ({
+  browserName: "chromium",
+  channel: process.env.BROWSER ?? "chrome",
+  viewport: { width: 1280, height: 720 },
+  permissions: ["clipboard-write", "clipboard-read"],
+  launchOptions: {
+    args: [
+      "--ignore-certificate-errors",
+      "--use-fake-ui-for-media-stream",
+      "--use-fake-device-for-media-stream",
+      ...(flags ?? []),
+    ],
+  },
+});
+
+export function createConfig(
+  projects: Projects,
+  addUseOptions: Partial<PlaywrightTestConfig["use"]> = {}
+): PlaywrightTestConfig {
+  return {
+    forbidOnly: !!process.env.CI,
+    projects: projects,
+    use: {
+      // Context options
+      ignoreHTTPSErrors: true,
+      contextOptions: {
+        locale: "en_GB",
+      },
+      // Artifacts
+      screenshot: "only-on-failure",
+      trace: "on-first-retry",
+      ...addUseOptions,
+    },
+    retries: process.env.CI ? 1 : 0,
+    reporter: process.env.CI ? [["github"], ["list"]] : [["list"]],
+  };
+}

--- a/examples/playwright.config.ts
+++ b/examples/playwright.config.ts
@@ -1,0 +1,13 @@
+import { PlaywrightTestConfig } from "@playwright/test";
+import { chromium, createConfig } from "./playwright.confg.base";
+
+const config: PlaywrightTestConfig = {
+  ...createConfig([
+    {
+      name: "fluent-components:stest:chromium",
+      use: chromium(),
+      testMatch: ["system-test/**.stest.ts"],
+    },
+  ]),
+};
+export default config;

--- a/examples/system-test/home-page.stest.ts
+++ b/examples/system-test/home-page.stest.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "@playwright/test";
+import { goToPage } from "./utils";
+
+test("should be able to navigate to home page", async ({ page }) => {
+  await goToPage(page);
+
+  const homePage = page.locator("#welcome-page");
+
+  await expect(homePage).toBeVisible();
+});

--- a/examples/system-test/utils.ts
+++ b/examples/system-test/utils.ts
@@ -1,0 +1,17 @@
+import { Page } from "@playwright/test";
+
+const GH_PAGE = "https://axiscommunications.github.io/fluent-components/";
+const LOCAL_HOST = "http://127.0.0.1:3000/fluent-components/";
+
+export function goToPage(page: Page, url?: string) {
+  if (url) {
+    return page.goto(url);
+  }
+
+  const envUrl = isCi() ? GH_PAGE : LOCAL_HOST;
+  return page.goto(envUrl);
+}
+
+export function isCi(): boolean {
+  return process.env.CI === "true";
+}

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "lib": ["es5", "es6", "dom", "dom.iterable", "ES2015", "es2017"],
+    "types": ["node"],
     "paths": {
       "@axiscommunications/fluent-hooks": ["hooks/src"],
       "@axiscommunications/fluent-password-input": [
@@ -18,5 +19,5 @@
       ]
     }
   },
-  "include": ["src"]
+  "include": ["src", "system-test", "*.ts"]
 }

--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -5,6 +5,9 @@ import path from "path";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    port: 3000,
+  },
   base: "/fluent-components/",
   resolve: {
     alias: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -359,6 +363,12 @@ importers:
         specifier: ^3.0.9
         version: 3.2.5(@types/node@20.8.8)
     devDependencies:
+      '@playwright/test':
+        specifier: 1.38.1
+        version: 1.38.1
+      '@types/node':
+        specifier: ^20.8.4
+        version: 20.8.8
       '@types/react':
         specifier: ^17.0.67
         version: 17.0.67
@@ -6426,6 +6436,14 @@ packages:
       fastq: 1.15.0
     dev: true
 
+  /@playwright/test@1.38.1:
+    resolution: {integrity: sha512-NqRp8XMwj3AK+zKLbZShl0r/9wKgzqI/527bkptKXomtuo+dOjU9NdMASQ8DNC9z9zLOMbG53T4eihYr3XR+BQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      playwright: 1.38.1
+    dev: true
+
   /@remix-run/router@1.10.0:
     resolution: {integrity: sha512-Lm+fYpMfZoEucJ7cMxgt4dYt8jLfbpwRCzAjm9UgSLOkmlqo9gupxt6YX3DY0Fk155NT9l17d/ydi+964uS9Lw==}
     engines: {node: '>=14.0.0'}
@@ -8857,6 +8875,14 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
+  /fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -10367,6 +10393,22 @@ packages:
       jsonc-parser: 3.2.0
       mlly: 1.4.2
       pathe: 1.1.1
+    dev: true
+
+  /playwright-core@1.38.1:
+    resolution: {integrity: sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dev: true
+
+  /playwright@1.38.1:
+    resolution: {integrity: sha512-oRMSJmZrOu1FP5iu3UrCx8JEFRIMxLDM0c/3o4bpzU5Tz97BypefWf7TuTNPWeCe279TPal5RtPPZ+9lW/Qkow==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      playwright-core: 1.38.1
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /please-upgrade-node@3.2.0:
@@ -12161,7 +12203,6 @@ packages:
   file:tools:
     resolution: {directory: tools, type: directory}
     name: tools
-    version: 8.3.1
     hasBin: true
     dependencies:
       cmd-ts: 0.13.0
@@ -12169,7 +12210,3 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
Adds playwright system test to check gh-page, runs on new github workflow
<img width="577" alt="image" src="https://github.com/AxisCommunications/fluent-components/assets/105843747/8d158784-bdd7-4254-99b3-378126bbe620">

This is the inital commit with core components for this purpose, it will be extended.

**github workflow trigger**
Currently only run on push main 
Also able to be triggered on dispatch for test
Also run on this branch currently, only temp (så u can see check)
- in **future** i plan this to run on schedueled interval as heartbeat test to verify gh-page
- also to run like 30min after push main (when gh-page deployed)

Also URLS to test with be added to variable in gh env eg (currently hardcoded)

**reporting**
It will only upload playwright report/artifact if test fails, can be found on github workflow summary page
Also i plan to send this report to team channel when fail :)
Artifact will contain screenshoot and more

**adding system test**
Currently running all playwright test named *stest* in examples/system-test folder, see playwright config for details

**misc**
This addition "should not" affect anything, its independent and locked to example project