### PR TITLE
feat(topbar): handle resourcegroup in query params

### DIFF
--- a/components/topbar/src/context.spec.ts
+++ b/components/topbar/src/context.spec.ts
@@ -4,17 +4,20 @@ describe("topbar settings", () => {
   const org = "arn:organization:0000";
   const lang = "en";
   const theme = "dark";
+  const rg = "resourcegroup";
 
   it("parser should extract valid search params", () => {
     const searchParams = {
       lang,
       org,
       theme,
+      rg,
     };
     const topBarSettingsParams = contextFromSearchParams(searchParams);
     expect(topBarSettingsParams.lang).toBe(lang);
     expect(topBarSettingsParams.org).toBe(org);
     expect(topBarSettingsParams.theme).toBe(theme);
+    expect(topBarSettingsParams.rg).toBe(rg);
   });
 
   it("parser should ignore invalid and non-setting parameters", () => {
@@ -22,6 +25,7 @@ describe("topbar settings", () => {
       lang: true,
       org: 9,
       theme: { 0: 0 },
+      rg: 666,
       nonSetting: "ceci-nest-pas-un-setting",
       ["⚗"]: "alembic",
     };
@@ -29,6 +33,7 @@ describe("topbar settings", () => {
     expect(topBarSettingsParams.lang).toBe(undefined);
     expect(topBarSettingsParams.org).toBe(undefined);
     expect(topBarSettingsParams.theme).toBe(undefined);
+    expect(topBarSettingsParams.rg).toBe(undefined);
   });
 
   it("serializer should add valid settings to URL search params", () => {
@@ -37,10 +42,11 @@ describe("topbar settings", () => {
       lang,
       org,
       theme,
+      rg,
     };
     const urlWithSettings = buildUrlWithContext(url, searchParams);
     expect(urlWithSettings).toBe(
-      "https://app.my.axis.com/?lang=en&org=arn%3Aorganization%3A0000&theme=dark"
+      "https://app.my.axis.com/?lang=en&org=arn%3Aorganization%3A0000&theme=dark&rg=resourcegroup"
     );
   });
 

--- a/components/topbar/src/context.ts
+++ b/components/topbar/src/context.ts
@@ -1,5 +1,5 @@
-export const topBarContextKeys = ["lang", "org", "theme"] as const;
-export type TopBarContextKey = typeof topBarContextKeys[number];
+export const topBarContextKeys = ["lang", "org", "theme", "rg"] as const;
+export type TopBarContextKey = (typeof topBarContextKeys)[number];
 export type TopBarContext = Partial<Record<TopBarContextKey, string>>;
 
 const _contextKeys = new Set(topBarContextKeys);


### PR DESCRIPTION
### Describe your changes

It is requested that we support sending resource group between applications in mySystems. One step towards that is to support parsing of resource group in  topbar helper function (the same way as organization, theme and language is done).

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
