### PR TITLE
fix(topbar): application menu icon visible also when hovering selected button

### DIFF
--- a/components/topbar/src/application.styles.ts
+++ b/components/topbar/src/application.styles.ts
@@ -55,6 +55,7 @@ export const useStyles = makeStyles({
     display: "flex",
     pointerEvents: "none",
     position: "absolute",
+    zIndex: 10,
     width: "34px",
     height: "32px",
     alignItems: "center",


### PR DESCRIPTION
### Describe your changes

Set z-index of application menu icon rectangle to avoid it getting hidden under the button, which was the case when hovering the selected button during tab navigation.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
