### PR TITLE
chore: add statusColor to theme preview

### DIFF
--- a/examples/src/stories/theme-page.tsx
+++ b/examples/src/stories/theme-page.tsx
@@ -130,6 +130,7 @@ const tokenVariant = {
   transparent: "colorTransparent",
   stroke: "colorStroke",
   compound: "colorCompound",
+  status: "colorStatus",
 } as const;
 
 type TtokenVariant = typeof tokenVariant[keyof typeof tokenVariant];
@@ -210,6 +211,7 @@ export const ThemePage = () => {
                   onTabSelect={onVariantSelect}
                 >
                   <Tab value={tokenVariant.brand}>Brand</Tab>
+                  <Tab value={tokenVariant.status}>Status</Tab>
                   <Tab value={tokenVariant.neutral}>Neutral</Tab>
                   <Tab value={tokenVariant.palette}>Palette</Tab>
                   <Tab value={tokenVariant.subtle}>Subtle</Tab>


### PR DESCRIPTION
Adds status color tokens to theme preview page:
<img width="732" alt="image" src="https://github.com/AxisCommunications/fluent-components/assets/105843747/7ab8f223-5006-4c41-8fba-d7d5d6182900">
