### PR TITLE
feat: able to always show slider labels

### DIFF
--- a/components/slider/src/__snapshots__/range-slider.spec.tsx.snap
+++ b/components/slider/src/__snapshots__/range-slider.spec.tsx.snap
@@ -20,7 +20,7 @@ exports[`range-slider > should render 1`] = `
             />
           </span>
           <div
-            class="axis-Slider__thumb ___14hb9vm_jmfl5w0 f8fbkgy f1nfllo7 f1djnp8u f1s8kh49 f22iagw f4d9j23 f122n59 f1euv43f f1t2h5zl f4aqd28 f1i1t8d1 f1vcxb5z fk1lali f1ewtqcl frcgkvu feh19e8 f3j3guj fo75joz f1yag6sl fsc6avr f1w15cjc fkaq55s f1fp5o0y f163fonl f1yq6w5o f11yjt3y f1jpmc5p f10tv6oz f16xp3sf fwrmqbx f1seuxxq f1j7ml58 f14u7mkt f5zrw40 fto0uou f1ks5ppg fyl8oag f1wl9k8s f1mdlcz9 fmmikit f10awi5f f1mfomsq fftmtmu f13zj6fq fgougqc fprarqb f14vs0nd f1gtfqs9 f18zvfd9 f8sy9bk fufffdp f1sclg23 f132a78j fcetbih f1kt6s4o"
+            class="axis-Slider__thumb ___ffv4vt0_dzc5jd0 f8fbkgy f1nfllo7 f1djnp8u f1s8kh49 f19g0ac f22iagw f4d9j23 f122n59 f1euv43f f1t2h5zl f4aqd28 f1i1t8d1 f1vcxb5z fk1lali f1ewtqcl frcgkvu f1nebdzw feh19e8 f3j3guj fo75joz f1yag6sl fsc6avr f1w15cjc fkaq55s f1fp5o0y f163fonl f1yq6w5o f11yjt3y f1jpmc5p f10tv6oz f16xp3sf fwrmqbx f1seuxxq f1j7ml58 f14u7mkt f5zrw40 fto0uou f1ks5ppg fyl8oag f1wl9k8s f1mdlcz9 fmmikit f10awi5f f1mfomsq fftmtmu f13zj6fq fgougqc fprarqb f14vs0nd f1gtfqs9 f18zvfd9 f8sy9bk fufffdp f1sclg23 f132a78j fcetbih f1kt6s4o"
             style="left: 20%;"
           >
             <input
@@ -32,13 +32,13 @@ exports[`range-slider > should render 1`] = `
               value="20"
             />
             <span
-              class="axis-Slider__thumb-label ___1b1bz8r_1eqf7oo fk116j8 fg8tfde fpvge99 fv71qf3 f1ywm7hm fw5db7e f14wxoun f1uw59to f1aa9q02 f16jpd5f f1jar5jt fyu767a f1euv43f feml9b3 f22iagw f122n59 f4d9j23 fxugw4r f18ygdci fxeb0a7 f1j7ml58 f1wl9k8s f15w9qf9 f1js41m7 fguqkdo f1ljr5q2 fto0uou f1hr5hl2 f1brpl1h"
+              class="axis-Slider__thumb-label ___1tp487w_n2k8qq0 fk116j8 fg8tfde fpvge99 fv71qf3 f1ywm7hm fw5db7e f14wxoun f1uw59to f1aa9q02 f16jpd5f f1jar5jt fyu767a f10pi13n feml9b3 f22iagw f122n59 f4d9j23 fxugw4r f18ygdci fxeb0a7 fv6wr3j f1j7ml58 f1wl9k8s f15w9qf9 f1js41m7 fguqkdo f1ljr5q2 fto0uou f1hr5hl2 f1brpl1h"
             >
               20
             </span>
           </div>
           <div
-            class="axis-Slider__thumb ___14hb9vm_jmfl5w0 f8fbkgy f1nfllo7 f1djnp8u f1s8kh49 f22iagw f4d9j23 f122n59 f1euv43f f1t2h5zl f4aqd28 f1i1t8d1 f1vcxb5z fk1lali f1ewtqcl frcgkvu feh19e8 f3j3guj fo75joz f1yag6sl fsc6avr f1w15cjc fkaq55s f1fp5o0y f163fonl f1yq6w5o f11yjt3y f1jpmc5p f10tv6oz f16xp3sf fwrmqbx f1seuxxq f1j7ml58 f14u7mkt f5zrw40 fto0uou f1ks5ppg fyl8oag f1wl9k8s f1mdlcz9 fmmikit f10awi5f f1mfomsq fftmtmu f13zj6fq fgougqc fprarqb f14vs0nd f1gtfqs9 f18zvfd9 f8sy9bk fufffdp f1sclg23 f132a78j fcetbih f1kt6s4o"
+            class="axis-Slider__thumb ___ffv4vt0_dzc5jd0 f8fbkgy f1nfllo7 f1djnp8u f1s8kh49 f19g0ac f22iagw f4d9j23 f122n59 f1euv43f f1t2h5zl f4aqd28 f1i1t8d1 f1vcxb5z fk1lali f1ewtqcl frcgkvu f1nebdzw feh19e8 f3j3guj fo75joz f1yag6sl fsc6avr f1w15cjc fkaq55s f1fp5o0y f163fonl f1yq6w5o f11yjt3y f1jpmc5p f10tv6oz f16xp3sf fwrmqbx f1seuxxq f1j7ml58 f14u7mkt f5zrw40 fto0uou f1ks5ppg fyl8oag f1wl9k8s f1mdlcz9 fmmikit f10awi5f f1mfomsq fftmtmu f13zj6fq fgougqc fprarqb f14vs0nd f1gtfqs9 f18zvfd9 f8sy9bk fufffdp f1sclg23 f132a78j fcetbih f1kt6s4o"
             style="left: 40%;"
           >
             <input
@@ -50,7 +50,7 @@ exports[`range-slider > should render 1`] = `
               value="40"
             />
             <span
-              class="axis-Slider__thumb-label ___1b1bz8r_1eqf7oo fk116j8 fg8tfde fpvge99 fv71qf3 f1ywm7hm fw5db7e f14wxoun f1uw59to f1aa9q02 f16jpd5f f1jar5jt fyu767a f1euv43f feml9b3 f22iagw f122n59 f4d9j23 fxugw4r f18ygdci fxeb0a7 f1j7ml58 f1wl9k8s f15w9qf9 f1js41m7 fguqkdo f1ljr5q2 fto0uou f1hr5hl2 f1brpl1h"
+              class="axis-Slider__thumb-label ___1tp487w_n2k8qq0 fk116j8 fg8tfde fpvge99 fv71qf3 f1ywm7hm fw5db7e f14wxoun f1uw59to f1aa9q02 f16jpd5f f1jar5jt fyu767a f10pi13n feml9b3 f22iagw f122n59 f4d9j23 fxugw4r f18ygdci fxeb0a7 fv6wr3j f1j7ml58 f1wl9k8s f15w9qf9 f1js41m7 fguqkdo f1ljr5q2 fto0uou f1hr5hl2 f1brpl1h"
             >
               40
             </span>
@@ -75,7 +75,7 @@ exports[`range-slider > should render 1`] = `
           />
         </span>
         <div
-          class="axis-Slider__thumb ___14hb9vm_jmfl5w0 f8fbkgy f1nfllo7 f1djnp8u f1s8kh49 f22iagw f4d9j23 f122n59 f1euv43f f1t2h5zl f4aqd28 f1i1t8d1 f1vcxb5z fk1lali f1ewtqcl frcgkvu feh19e8 f3j3guj fo75joz f1yag6sl fsc6avr f1w15cjc fkaq55s f1fp5o0y f163fonl f1yq6w5o f11yjt3y f1jpmc5p f10tv6oz f16xp3sf fwrmqbx f1seuxxq f1j7ml58 f14u7mkt f5zrw40 fto0uou f1ks5ppg fyl8oag f1wl9k8s f1mdlcz9 fmmikit f10awi5f f1mfomsq fftmtmu f13zj6fq fgougqc fprarqb f14vs0nd f1gtfqs9 f18zvfd9 f8sy9bk fufffdp f1sclg23 f132a78j fcetbih f1kt6s4o"
+          class="axis-Slider__thumb ___ffv4vt0_dzc5jd0 f8fbkgy f1nfllo7 f1djnp8u f1s8kh49 f19g0ac f22iagw f4d9j23 f122n59 f1euv43f f1t2h5zl f4aqd28 f1i1t8d1 f1vcxb5z fk1lali f1ewtqcl frcgkvu f1nebdzw feh19e8 f3j3guj fo75joz f1yag6sl fsc6avr f1w15cjc fkaq55s f1fp5o0y f163fonl f1yq6w5o f11yjt3y f1jpmc5p f10tv6oz f16xp3sf fwrmqbx f1seuxxq f1j7ml58 f14u7mkt f5zrw40 fto0uou f1ks5ppg fyl8oag f1wl9k8s f1mdlcz9 fmmikit f10awi5f f1mfomsq fftmtmu f13zj6fq fgougqc fprarqb f14vs0nd f1gtfqs9 f18zvfd9 f8sy9bk fufffdp f1sclg23 f132a78j fcetbih f1kt6s4o"
           style="left: 20%;"
         >
           <input
@@ -87,13 +87,13 @@ exports[`range-slider > should render 1`] = `
             value="20"
           />
           <span
-            class="axis-Slider__thumb-label ___1b1bz8r_1eqf7oo fk116j8 fg8tfde fpvge99 fv71qf3 f1ywm7hm fw5db7e f14wxoun f1uw59to f1aa9q02 f16jpd5f f1jar5jt fyu767a f1euv43f feml9b3 f22iagw f122n59 f4d9j23 fxugw4r f18ygdci fxeb0a7 f1j7ml58 f1wl9k8s f15w9qf9 f1js41m7 fguqkdo f1ljr5q2 fto0uou f1hr5hl2 f1brpl1h"
+            class="axis-Slider__thumb-label ___1tp487w_n2k8qq0 fk116j8 fg8tfde fpvge99 fv71qf3 f1ywm7hm fw5db7e f14wxoun f1uw59to f1aa9q02 f16jpd5f f1jar5jt fyu767a f10pi13n feml9b3 f22iagw f122n59 f4d9j23 fxugw4r f18ygdci fxeb0a7 fv6wr3j f1j7ml58 f1wl9k8s f15w9qf9 f1js41m7 fguqkdo f1ljr5q2 fto0uou f1hr5hl2 f1brpl1h"
           >
             20
           </span>
         </div>
         <div
-          class="axis-Slider__thumb ___14hb9vm_jmfl5w0 f8fbkgy f1nfllo7 f1djnp8u f1s8kh49 f22iagw f4d9j23 f122n59 f1euv43f f1t2h5zl f4aqd28 f1i1t8d1 f1vcxb5z fk1lali f1ewtqcl frcgkvu feh19e8 f3j3guj fo75joz f1yag6sl fsc6avr f1w15cjc fkaq55s f1fp5o0y f163fonl f1yq6w5o f11yjt3y f1jpmc5p f10tv6oz f16xp3sf fwrmqbx f1seuxxq f1j7ml58 f14u7mkt f5zrw40 fto0uou f1ks5ppg fyl8oag f1wl9k8s f1mdlcz9 fmmikit f10awi5f f1mfomsq fftmtmu f13zj6fq fgougqc fprarqb f14vs0nd f1gtfqs9 f18zvfd9 f8sy9bk fufffdp f1sclg23 f132a78j fcetbih f1kt6s4o"
+          class="axis-Slider__thumb ___ffv4vt0_dzc5jd0 f8fbkgy f1nfllo7 f1djnp8u f1s8kh49 f19g0ac f22iagw f4d9j23 f122n59 f1euv43f f1t2h5zl f4aqd28 f1i1t8d1 f1vcxb5z fk1lali f1ewtqcl frcgkvu f1nebdzw feh19e8 f3j3guj fo75joz f1yag6sl fsc6avr f1w15cjc fkaq55s f1fp5o0y f163fonl f1yq6w5o f11yjt3y f1jpmc5p f10tv6oz f16xp3sf fwrmqbx f1seuxxq f1j7ml58 f14u7mkt f5zrw40 fto0uou f1ks5ppg fyl8oag f1wl9k8s f1mdlcz9 fmmikit f10awi5f f1mfomsq fftmtmu f13zj6fq fgougqc fprarqb f14vs0nd f1gtfqs9 f18zvfd9 f8sy9bk fufffdp f1sclg23 f132a78j fcetbih f1kt6s4o"
           style="left: 40%;"
         >
           <input
@@ -105,7 +105,7 @@ exports[`range-slider > should render 1`] = `
             value="40"
           />
           <span
-            class="axis-Slider__thumb-label ___1b1bz8r_1eqf7oo fk116j8 fg8tfde fpvge99 fv71qf3 f1ywm7hm fw5db7e f14wxoun f1uw59to f1aa9q02 f16jpd5f f1jar5jt fyu767a f1euv43f feml9b3 f22iagw f122n59 f4d9j23 fxugw4r f18ygdci fxeb0a7 f1j7ml58 f1wl9k8s f15w9qf9 f1js41m7 fguqkdo f1ljr5q2 fto0uou f1hr5hl2 f1brpl1h"
+            class="axis-Slider__thumb-label ___1tp487w_n2k8qq0 fk116j8 fg8tfde fpvge99 fv71qf3 f1ywm7hm fw5db7e f14wxoun f1uw59to f1aa9q02 f16jpd5f f1jar5jt fyu767a f10pi13n feml9b3 f22iagw f122n59 f4d9j23 fxugw4r f18ygdci fxeb0a7 fv6wr3j f1j7ml58 f1wl9k8s f15w9qf9 f1js41m7 fguqkdo f1ljr5q2 fto0uou f1hr5hl2 f1brpl1h"
           >
             40
           </span>

--- a/components/slider/src/__snapshots__/slider.spec.tsx.snap
+++ b/components/slider/src/__snapshots__/slider.spec.tsx.snap
@@ -20,7 +20,7 @@ exports[`slider > should render 1`] = `
             />
           </span>
           <div
-            class="axis-Slider__thumb ___14hb9vm_jmfl5w0 f8fbkgy f1nfllo7 f1djnp8u f1s8kh49 f22iagw f4d9j23 f122n59 f1euv43f f1t2h5zl f4aqd28 f1i1t8d1 f1vcxb5z fk1lali f1ewtqcl frcgkvu feh19e8 f3j3guj fo75joz f1yag6sl fsc6avr f1w15cjc fkaq55s f1fp5o0y f163fonl f1yq6w5o f11yjt3y f1jpmc5p f10tv6oz f16xp3sf fwrmqbx f1seuxxq f1j7ml58 f14u7mkt f5zrw40 fto0uou f1ks5ppg fyl8oag f1wl9k8s f1mdlcz9 fmmikit f10awi5f f1mfomsq fftmtmu f13zj6fq fgougqc fprarqb f14vs0nd f1gtfqs9 f18zvfd9 f8sy9bk fufffdp f1sclg23 f132a78j fcetbih f1kt6s4o"
+            class="axis-Slider__thumb ___ffv4vt0_dzc5jd0 f8fbkgy f1nfllo7 f1djnp8u f1s8kh49 f19g0ac f22iagw f4d9j23 f122n59 f1euv43f f1t2h5zl f4aqd28 f1i1t8d1 f1vcxb5z fk1lali f1ewtqcl frcgkvu f1nebdzw feh19e8 f3j3guj fo75joz f1yag6sl fsc6avr f1w15cjc fkaq55s f1fp5o0y f163fonl f1yq6w5o f11yjt3y f1jpmc5p f10tv6oz f16xp3sf fwrmqbx f1seuxxq f1j7ml58 f14u7mkt f5zrw40 fto0uou f1ks5ppg fyl8oag f1wl9k8s f1mdlcz9 fmmikit f10awi5f f1mfomsq fftmtmu f13zj6fq fgougqc fprarqb f14vs0nd f1gtfqs9 f18zvfd9 f8sy9bk fufffdp f1sclg23 f132a78j fcetbih f1kt6s4o"
             style="left: 20%;"
           >
             <input
@@ -32,7 +32,7 @@ exports[`slider > should render 1`] = `
               value="20"
             />
             <span
-              class="axis-Slider__thumb-label ___1b1bz8r_1eqf7oo fk116j8 fg8tfde fpvge99 fv71qf3 f1ywm7hm fw5db7e f14wxoun f1uw59to f1aa9q02 f16jpd5f f1jar5jt fyu767a f1euv43f feml9b3 f22iagw f122n59 f4d9j23 fxugw4r f18ygdci fxeb0a7 f1j7ml58 f1wl9k8s f15w9qf9 f1js41m7 fguqkdo f1ljr5q2 fto0uou f1hr5hl2 f1brpl1h"
+              class="axis-Slider__thumb-label ___1tp487w_n2k8qq0 fk116j8 fg8tfde fpvge99 fv71qf3 f1ywm7hm fw5db7e f14wxoun f1uw59to f1aa9q02 f16jpd5f f1jar5jt fyu767a f10pi13n feml9b3 f22iagw f122n59 f4d9j23 fxugw4r f18ygdci fxeb0a7 fv6wr3j f1j7ml58 f1wl9k8s f15w9qf9 f1js41m7 fguqkdo f1ljr5q2 fto0uou f1hr5hl2 f1brpl1h"
             >
               20
             </span>
@@ -57,7 +57,7 @@ exports[`slider > should render 1`] = `
           />
         </span>
         <div
-          class="axis-Slider__thumb ___14hb9vm_jmfl5w0 f8fbkgy f1nfllo7 f1djnp8u f1s8kh49 f22iagw f4d9j23 f122n59 f1euv43f f1t2h5zl f4aqd28 f1i1t8d1 f1vcxb5z fk1lali f1ewtqcl frcgkvu feh19e8 f3j3guj fo75joz f1yag6sl fsc6avr f1w15cjc fkaq55s f1fp5o0y f163fonl f1yq6w5o f11yjt3y f1jpmc5p f10tv6oz f16xp3sf fwrmqbx f1seuxxq f1j7ml58 f14u7mkt f5zrw40 fto0uou f1ks5ppg fyl8oag f1wl9k8s f1mdlcz9 fmmikit f10awi5f f1mfomsq fftmtmu f13zj6fq fgougqc fprarqb f14vs0nd f1gtfqs9 f18zvfd9 f8sy9bk fufffdp f1sclg23 f132a78j fcetbih f1kt6s4o"
+          class="axis-Slider__thumb ___ffv4vt0_dzc5jd0 f8fbkgy f1nfllo7 f1djnp8u f1s8kh49 f19g0ac f22iagw f4d9j23 f122n59 f1euv43f f1t2h5zl f4aqd28 f1i1t8d1 f1vcxb5z fk1lali f1ewtqcl frcgkvu f1nebdzw feh19e8 f3j3guj fo75joz f1yag6sl fsc6avr f1w15cjc fkaq55s f1fp5o0y f163fonl f1yq6w5o f11yjt3y f1jpmc5p f10tv6oz f16xp3sf fwrmqbx f1seuxxq f1j7ml58 f14u7mkt f5zrw40 fto0uou f1ks5ppg fyl8oag f1wl9k8s f1mdlcz9 fmmikit f10awi5f f1mfomsq fftmtmu f13zj6fq fgougqc fprarqb f14vs0nd f1gtfqs9 f18zvfd9 f8sy9bk fufffdp f1sclg23 f132a78j fcetbih f1kt6s4o"
           style="left: 20%;"
         >
           <input
@@ -69,7 +69,7 @@ exports[`slider > should render 1`] = `
             value="20"
           />
           <span
-            class="axis-Slider__thumb-label ___1b1bz8r_1eqf7oo fk116j8 fg8tfde fpvge99 fv71qf3 f1ywm7hm fw5db7e f14wxoun f1uw59to f1aa9q02 f16jpd5f f1jar5jt fyu767a f1euv43f feml9b3 f22iagw f122n59 f4d9j23 fxugw4r f18ygdci fxeb0a7 f1j7ml58 f1wl9k8s f15w9qf9 f1js41m7 fguqkdo f1ljr5q2 fto0uou f1hr5hl2 f1brpl1h"
+            class="axis-Slider__thumb-label ___1tp487w_n2k8qq0 fk116j8 fg8tfde fpvge99 fv71qf3 f1ywm7hm fw5db7e f14wxoun f1uw59to f1aa9q02 f16jpd5f f1jar5jt fyu767a f10pi13n feml9b3 f22iagw f122n59 f4d9j23 fxugw4r f18ygdci fxeb0a7 fv6wr3j f1j7ml58 f1wl9k8s f15w9qf9 f1js41m7 fguqkdo f1ljr5q2 fto0uou f1hr5hl2 f1brpl1h"
           >
             20
           </span>

--- a/components/slider/src/slider.spec.tsx
+++ b/components/slider/src/slider.spec.tsx
@@ -271,6 +271,22 @@ describe("slider", () => {
       expect(label).toHaveStyle({ transform: "translateY(-100%) scale(1)" });
     });
 
+    it("should open labels always", () => {
+      const { getByTestId } = render(
+        <Slider
+          min={0}
+          max={100}
+          data-testid="slider-root"
+          defaultTooltipOpen
+        />
+      );
+
+      const label = getByTestId("slider-root").querySelector(
+        `.${sliderClassNames.thumb.label}`
+      );
+      expect(label).toHaveStyle({ transform: "translateY(-100%) scale(1)" });
+    });
+
     it("should close on mouse leave", () => {
       const { getByTestId, getByRole } = render(
         <Slider min={0} max={100} data-testid="slider-root" />

--- a/components/slider/src/slider.types.ts
+++ b/components/slider/src/slider.types.ts
@@ -45,6 +45,7 @@ export type RangeSliderProps =
     max: number;
     value?: number[];
     defaultValue?: number[];
+    defaultTooltipOpen?: boolean;
     onChange?: (data: RangeSliderOnChangeData) => void;
     onChangeCommitted?: (data: RangeSliderOnChangeData) => void;
     valueLabelTransform?: (value: number) => number | string;

--- a/components/slider/src/thumb/use-thumb-styles.ts
+++ b/components/slider/src/thumb/use-thumb-styles.ts
@@ -16,7 +16,7 @@ import {
 const useRootStyles = makeStyles({
   root: {
     ...shorthands.borderRadius(tokens.borderRadiusCircular),
-
+    zIndex: 1,
     display: "flex",
     justifyContent: "center",
     alignItems: "center",
@@ -29,6 +29,10 @@ const useRootStyles = makeStyles({
     boxSizing: "border-box",
     boxShadow:
       `0 0 0 calc(var(${sliderVars.thumb.size}) * .2) ${tokens.colorNeutralBackground1} inset`,
+
+    ":hover": {
+      zIndex: 5,
+    },
 
     "::before": {
       ...shorthands.borderRadius(tokens.borderRadiusCircular),
@@ -90,7 +94,7 @@ const useLabelStyles = makeStyles({
     ),
     ...shorthands.padding(tokens.spacingVerticalXS, tokens.spacingHorizontalM),
     ...shorthands.borderRadius(tokens.borderRadiusMedium),
-    position: "absolute",
+    position: "relative",
     top: "-10px",
     display: "flex",
     alignItems: "center",
@@ -99,6 +103,7 @@ const useLabelStyles = makeStyles({
     transformOrigin: "center bottom 0px",
     filter:
       `drop-shadow(0 0 2px ${tokens.colorNeutralShadowAmbient}) drop-shadow(0 4px 8px ${tokens.colorNeutralShadowKey})`,
+    textWrap: "nowrap",
 
     // this is the little arrow thingy below the label box
     "::before": {

--- a/components/slider/src/use-range-slider.ts
+++ b/components/slider/src/use-range-slider.ts
@@ -96,6 +96,7 @@ export const useRangeSlider_unstable = (
     value: values,
     onChange,
     onChangeCommitted,
+    defaultTooltipOpen = false,
   } = props;
 
   const [internalValues, setInternalValues] = useControllableState({
@@ -434,7 +435,7 @@ export const useRangeSlider_unstable = (
       value,
       valueLabelTransform,
       "data-index": index,
-      open: open === index || active === index,
+      open: open === index || active === index || defaultTooltipOpen,
       active: active === index,
       dragging,
       handleFocus: createHandleFocus(index),

--- a/examples/src/stories/slider-page.tsx
+++ b/examples/src/stories/slider-page.tsx
@@ -131,6 +131,19 @@ const DisabledSlider = () => {
   );
 };
 
+const RangeSliderWithLabelsAlwaysOpen = () => {
+  return (
+    <DemoRangeSlider
+      title={"Slider with custom labels always open"}
+      min={0}
+      max={100}
+      defaultValue={[10, 50]}
+      valueLabelTransform={(v) => `value ${v}`}
+      defaultTooltipOpen
+    />
+  );
+};
+
 const SliderWithRange = () => {
   return (
     <DemoRangeSlider
@@ -315,6 +328,7 @@ export const SliderPage = () => {
         <TransformedValueSlider />
         <SliderWithRange />
         <RangeSliderWithSteps />
+        <RangeSliderWithLabelsAlwaysOpen />
         <DisabledSlider />
         <SliderWithExternalButtons />
         <CustomizedSlider />


### PR DESCRIPTION
### Describe your changes

- Adds possibiblity to always show labels for thumbs, not only on hover.
<img width="485" alt="image" src="https://github.com/AxisCommunications/fluent-components/assets/105843747/824a3b14-3e4a-436b-b710-aedacac97db5">

- Also adjust so thumb on focus and its label are visible on hover by increase its z-index, good when using multiple thumbs (else thumb dragging could end up hidden behind other thumbs/labels)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
