### PR TITLE
feat: add tablist utilities styles and examples

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -37,6 +37,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "6.20.1",
+    "react-syntax-highlighter": "15.5.0",
     "scheduler": "0.23.0",
     "vite": "^3.0.9"
   },
@@ -45,6 +46,7 @@
     "@types/node": "^20.10.6",
     "@types/react": "^17.0.67",
     "@types/react-dom": "^17.0.21",
+    "@types/react-syntax-highlighter": "15.5.11",
     "eslint": "^8.56.0",
     "typescript": "^4.5.5"
   },

--- a/examples/src/components/code-block.tsx
+++ b/examples/src/components/code-block.tsx
@@ -1,0 +1,25 @@
+import SyntaxHighlighter from "react-syntax-highlighter";
+import React from "react";
+import {
+  Accordion,
+  AccordionHeader,
+  AccordionItem,
+  AccordionPanel,
+} from "@fluentui/react-components";
+
+export const CodeBlock = (
+  { codeString, title }: { codeString: string; title: string }
+) => {
+  return (
+    <Accordion collapsible>
+      <AccordionItem value="1">
+        <AccordionHeader>{title}</AccordionHeader>
+        <AccordionPanel>
+          <SyntaxHighlighter language="typescript">
+            {codeString}
+          </SyntaxHighlighter>
+        </AccordionPanel>
+      </AccordionItem>
+    </Accordion>
+  );
+};

--- a/examples/src/routing/route-map.tsx
+++ b/examples/src/routing/route-map.tsx
@@ -2,6 +2,8 @@ import {
   bundleIcon,
   DarkThemeFilled,
   DarkThemeRegular,
+  DocumentCssFilled,
+  DocumentCssRegular,
   EyeFilled,
   EyeRegular,
   HomeFilled,
@@ -25,6 +27,7 @@ import { routes, TRoute } from "./routes";
 import { SliderPage } from "../stories/slider-page";
 import { WelcomePage } from "../landingpage";
 import { PasswordInputPage } from "../stories/password-input-page";
+import { FluentUiTabStylesPage } from "../stories/tab-list-utilities/tab-list-utilities-page";
 
 const HomeIcon = bundleIcon(HomeFilled, HomeRegular);
 const ThemeIcon = bundleIcon(DarkThemeFilled, DarkThemeRegular);
@@ -34,6 +37,7 @@ const VStepperIcon = bundleIcon(StepsFilled, StepsRegular);
 const TableUtilitiesIcon = bundleIcon(TableFilled, TableRegular);
 const SliderIcon = bundleIcon(OptionsFilled, OptionsRegular);
 const PasswordIcon = bundleIcon(EyeFilled, EyeRegular);
+const TabStylesIcon = bundleIcon(DocumentCssFilled, DocumentCssRegular);
 
 export enum RouteGroup {
   MISC,
@@ -94,15 +98,6 @@ export const routeMap: Map<TRoute, TRouteData> = new Map([
     },
   ],
   [
-    routes.TableUtilities,
-    {
-      label: "Table Utilities",
-      element: <TableUtilitiesPage />,
-      icon: <TableUtilitiesIcon />,
-      group: RouteGroup.STORY,
-    },
-  ],
-  [
     routes.Slider,
     {
       label: "Slider",
@@ -117,6 +112,24 @@ export const routeMap: Map<TRoute, TRouteData> = new Map([
       label: "Password input",
       element: <PasswordInputPage />,
       icon: <PasswordIcon />,
+      group: RouteGroup.STORY,
+    },
+  ],
+  [
+    routes.TableUtilities,
+    {
+      label: "Table Utilities",
+      element: <TableUtilitiesPage />,
+      icon: <TableUtilitiesIcon />,
+      group: RouteGroup.STORY,
+    },
+  ],
+  [
+    routes.PasswordInput,
+    {
+      label: "Tablist utilities",
+      element: <FluentUiTabStylesPage />,
+      icon: <TabStylesIcon />,
       group: RouteGroup.STORY,
     },
   ],

--- a/examples/src/stories/tab-list-utilities/tab-list-styled..tsx
+++ b/examples/src/stories/tab-list-utilities/tab-list-styled..tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import {
-  mergeClasses,
   Tab,
   TabList,
   TabListProps,

--- a/examples/src/stories/tab-list-utilities/tab-list-styled..tsx
+++ b/examples/src/stories/tab-list-utilities/tab-list-styled..tsx
@@ -1,0 +1,163 @@
+import React from "react";
+import {
+  mergeClasses,
+  Tab,
+  TabList,
+  TabListProps,
+  TabProps,
+} from "@fluentui/react-components";
+import { bundleIcon, HomeFilled, HomeRegular } from "@fluentui/react-icons";
+import {
+  useTabListStyles,
+  useTabStyles,
+} from "@axiscommunications/fluent-styles";
+import { useTabListContext } from "./tab-list-utilities-page";
+
+export const codeBlockStyled = `
+import {
+  useTabListStyles,
+  useTabStyles,
+} from "@axiscommunications/fluent-styles";
+
+type TTabListComponent = {
+  withText?: boolean;
+} & TabListProps;
+
+function StyledTabListComponent(
+  { withText = true, ...props }: TTabListComponent
+) {
+  const { selectedTab, setSelectedTab } = useTabListContext()
+  const styles = useTabListStyles();
+  const rootStyles = mergeClasses(
+    styles.root,
+    props.vertical && styles.vertical
+  );
+  return (
+    <TabList
+      selectedValue={selectedTab}
+      className={rootStyles}
+      defaultSelectedValue={selectedTab}
+      onTabSelect={(_, { value }) => {
+        setSelectedTab(value as unknown as string);
+      }}
+      {...props}
+    >
+      <StyledTabComponent
+        icon={<HomeIcon />}
+        value="tab1"
+        selected={selectedTab === "tab1"}
+      >
+        {withText && "First Tab"}
+      </StyledTabComponent>
+      <StyledTabComponent
+        icon={<HomeIcon />}
+        value="tab2"
+        selected={selectedTab === "tab2"}
+      >
+        {withText && "First Tab"}
+      </StyledTabComponent>
+      <StyledTabComponent
+        icon={<HomeIcon />}
+        value="tab3"
+        selected={selectedTab === "tab3"}
+      >
+        {withText && "First Tab"}
+      </StyledTabComponent>
+    </TabList>
+  );
+}
+
+type TStyledTabComponent = {
+  selected?: boolean;
+} & TabProps;
+
+function StyledTabComponent(
+  { selected, children, ...props }: TStyledTabComponent
+) {
+  const styles = useTabStyles();
+  const rootStyles = mergeClasses(styles.root, selected && styles.selected);
+  return <Tab className={rootStyles} {...props}>{children}</Tab>;
+}
+`;
+
+const HomeIcon = bundleIcon(HomeFilled, HomeRegular);
+
+export type TTabListComponent = {
+  withText?: boolean;
+} & TabListProps;
+
+export function StyledTabListComponent(
+  { withText = true, ...props }: TTabListComponent
+) {
+  const { selectedTab, setSelectedTab } = useTabListContext();
+  const styles = useTabListStyles();
+  const rootStyles = mergeClasses(
+    styles.root,
+    props.vertical && styles.vertical
+  );
+  return (
+    <TabList
+      selectedValue={selectedTab}
+      className={rootStyles}
+      defaultSelectedValue={selectedTab}
+      onTabSelect={(_, { value }) => {
+        setSelectedTab(value as unknown as string);
+      }}
+      {...props}
+    >
+      <StyledTabComponent
+        icon={<HomeIcon />}
+        value="tab1"
+        selected={selectedTab === "tab1"}
+      >
+        {withText && "First Tab"}
+      </StyledTabComponent>
+      <StyledTabComponent
+        icon={<HomeIcon />}
+        value="tab2"
+        selected={selectedTab === "tab2"}
+      >
+        {withText && "First Tab"}
+      </StyledTabComponent>
+      <StyledTabComponent
+        icon={<HomeIcon />}
+        value="tab3"
+        selected={selectedTab === "tab3"}
+      >
+        {withText && "First Tab"}
+      </StyledTabComponent>
+    </TabList>
+  );
+}
+
+export type TStyledTabComponent = {
+  selected?: boolean;
+} & TabProps;
+
+function StyledTabComponent(
+  { selected, children, ...props }: TStyledTabComponent
+) {
+  const styles = useTabStyles();
+  const rootStyles = mergeClasses(styles.root, selected && styles.selected);
+  return <Tab className={rootStyles} {...props}>{children}</Tab>;
+}
+
+export function TabListComponent(
+  { withText = true, ...props }: TTabListComponent
+) {
+  const { selectedTab, setSelectedTab } = useTabListContext();
+  return (
+    <TabList
+      selectedValue={selectedTab}
+      defaultSelectedValue={selectedTab}
+      onTabSelect={(_, { value }) => {
+        setSelectedTab(value as unknown as string);
+      }}
+      {...props}
+    >
+      <Tab icon={<HomeIcon />} value="tab1">{withText && "First Tab"}</Tab>
+      <Tab icon={<HomeIcon />} value="tab2">{withText && "First Tab"}</Tab>
+      <Tab icon={<HomeIcon />} value="tab3">{withText && "First Tab"}</Tab>
+    </TabList>
+  );
+}

--- a/examples/src/stories/tab-list-utilities/tab-list-styled..tsx
+++ b/examples/src/stories/tab-list-utilities/tab-list-styled..tsx
@@ -20,64 +20,18 @@ import {
 } from "@axiscommunications/fluent-styles";
 ...
 
-const HomeIcon = bundleIcon(HomeFilled, HomeRegular);
+//standard usage
+const { rootStyle: tabListStyle } = useTabListStyles({ vertical: true/false });
+const { rootStyle: tabStyle } = useTabStyles({ selected: true/false });
 
-export type TTabListComponent = {
-  withText?: boolean;
-} & TabListProps;
+<Tab className={tabListStyle} {...TabListProps}>
+    <Tab className={tabStyle} {...TabProps}>tab1</Tab>
+</Tab>
 
-export function StyledTabListComponent(
-  { withText = true, ...props }: TTabListComponent
-) {
-  const { selectedTab, setSelectedTab } = useTabListContext();
-  const { rootStyle } = useTabListStyles({ vertical: props.vertical });
-
-  return (
-    <TabList
-      selectedValue={selectedTab}
-      className={rootStyle}
-      defaultSelectedValue={selectedTab}
-      onTabSelect={(_, { value }) => {
-        setSelectedTab(value as unknown as string);
-      }}
-      {...props}
-    >
-      <StyledTabComponent
-        icon={<HomeIcon />}
-        value="tab1"
-        selected={selectedTab === "tab1"}
-      >
-        {withText && "First Tab"}
-      </StyledTabComponent>
-      <StyledTabComponent
-        icon={<HomeIcon />}
-        value="tab2"
-        selected={selectedTab === "tab2"}
-      >
-        {withText && "First Tab"}
-      </StyledTabComponent>
-      <StyledTabComponent
-        icon={<HomeIcon />}
-        value="tab3"
-        selected={selectedTab === "tab3"}
-      >
-        {withText && "First Tab"}
-      </StyledTabComponent>
-    </TabList>
-  );
-}
-
-export type TStyledTabComponent = {
-  selected?: boolean;
-} & TabProps;
-
-function StyledTabComponent(
-  { selected, children, ...props }: TStyledTabComponent
-) {
-  const { rootStyle } = useTabStyles({ selected });
-
-  return <Tab className={rootStyle} {...props}>{children}</Tab>;
-}
+//not happy with style? all styles can be grabbed from styles prop
+const { styles } = useTabListStyles();
+const newStyle = mergeClasses(styles.root, overrideStyles.root ...)
+...
 `;
 
 const HomeIcon = bundleIcon(HomeFilled, HomeRegular);

--- a/examples/src/stories/tab-list-utilities/tab-list-styled..tsx
+++ b/examples/src/stories/tab-list-utilities/tab-list-styled..tsx
@@ -14,71 +14,12 @@ import {
 import { useTabListContext } from "./tab-list-utilities-page";
 
 export const codeBlockStyled = `
+...
 import {
   useTabListStyles,
   useTabStyles,
 } from "@axiscommunications/fluent-styles";
-
-type TTabListComponent = {
-  withText?: boolean;
-} & TabListProps;
-
-function StyledTabListComponent(
-  { withText = true, ...props }: TTabListComponent
-) {
-  const { selectedTab, setSelectedTab } = useTabListContext()
-  const styles = useTabListStyles();
-  const rootStyles = mergeClasses(
-    styles.root,
-    props.vertical && styles.vertical
-  );
-  return (
-    <TabList
-      selectedValue={selectedTab}
-      className={rootStyles}
-      defaultSelectedValue={selectedTab}
-      onTabSelect={(_, { value }) => {
-        setSelectedTab(value as unknown as string);
-      }}
-      {...props}
-    >
-      <StyledTabComponent
-        icon={<HomeIcon />}
-        value="tab1"
-        selected={selectedTab === "tab1"}
-      >
-        {withText && "First Tab"}
-      </StyledTabComponent>
-      <StyledTabComponent
-        icon={<HomeIcon />}
-        value="tab2"
-        selected={selectedTab === "tab2"}
-      >
-        {withText && "First Tab"}
-      </StyledTabComponent>
-      <StyledTabComponent
-        icon={<HomeIcon />}
-        value="tab3"
-        selected={selectedTab === "tab3"}
-      >
-        {withText && "First Tab"}
-      </StyledTabComponent>
-    </TabList>
-  );
-}
-
-type TStyledTabComponent = {
-  selected?: boolean;
-} & TabProps;
-
-function StyledTabComponent(
-  { selected, children, ...props }: TStyledTabComponent
-) {
-  const styles = useTabStyles();
-  const rootStyles = mergeClasses(styles.root, selected && styles.selected);
-  return <Tab className={rootStyles} {...props}>{children}</Tab>;
-}
-`;
+...
 
 const HomeIcon = bundleIcon(HomeFilled, HomeRegular);
 
@@ -90,15 +31,12 @@ export function StyledTabListComponent(
   { withText = true, ...props }: TTabListComponent
 ) {
   const { selectedTab, setSelectedTab } = useTabListContext();
-  const styles = useTabListStyles();
-  const rootStyles = mergeClasses(
-    styles.root,
-    props.vertical && styles.vertical
-  );
+  const { rootStyle } = useTabListStyles({ vertical: props.vertical });
+
   return (
     <TabList
       selectedValue={selectedTab}
-      className={rootStyles}
+      className={rootStyle}
       defaultSelectedValue={selectedTab}
       onTabSelect={(_, { value }) => {
         setSelectedTab(value as unknown as string);
@@ -137,27 +75,67 @@ export type TStyledTabComponent = {
 function StyledTabComponent(
   { selected, children, ...props }: TStyledTabComponent
 ) {
-  const styles = useTabStyles();
-  const rootStyles = mergeClasses(styles.root, selected && styles.selected);
-  return <Tab className={rootStyles} {...props}>{children}</Tab>;
-}
+  const { rootStyle } = useTabStyles({ selected });
 
-export function TabListComponent(
+  return <Tab className={rootStyle} {...props}>{children}</Tab>;
+}
+`;
+
+const HomeIcon = bundleIcon(HomeFilled, HomeRegular);
+
+export type TTabListComponent = {
+  withText?: boolean;
+} & TabListProps;
+
+export function StyledTabListComponent(
   { withText = true, ...props }: TTabListComponent
 ) {
   const { selectedTab, setSelectedTab } = useTabListContext();
+  const { rootStyle } = useTabListStyles({ vertical: props.vertical });
+
   return (
     <TabList
       selectedValue={selectedTab}
+      className={rootStyle}
       defaultSelectedValue={selectedTab}
       onTabSelect={(_, { value }) => {
         setSelectedTab(value as unknown as string);
       }}
       {...props}
     >
-      <Tab icon={<HomeIcon />} value="tab1">{withText && "First Tab"}</Tab>
-      <Tab icon={<HomeIcon />} value="tab2">{withText && "First Tab"}</Tab>
-      <Tab icon={<HomeIcon />} value="tab3">{withText && "First Tab"}</Tab>
+      <StyledTabComponent
+        icon={<HomeIcon />}
+        value="tab1"
+        selected={selectedTab === "tab1"}
+      >
+        {withText && "First Tab"}
+      </StyledTabComponent>
+      <StyledTabComponent
+        icon={<HomeIcon />}
+        value="tab2"
+        selected={selectedTab === "tab2"}
+      >
+        {withText && "First Tab"}
+      </StyledTabComponent>
+      <StyledTabComponent
+        icon={<HomeIcon />}
+        value="tab3"
+        selected={selectedTab === "tab3"}
+      >
+        {withText && "First Tab"}
+      </StyledTabComponent>
     </TabList>
   );
+}
+
+export type TStyledTabComponent = {
+  selected?: boolean;
+} & TabProps;
+
+function StyledTabComponent(
+  { selected, children, ...props }: TStyledTabComponent
+) {
+  const { rootStyle } = useTabStyles({ selected });
+
+  return <Tab className={rootStyle} {...props}>{children}</Tab>;
 }

--- a/examples/src/stories/tab-list-utilities/tab-list-utilities-page.tsx
+++ b/examples/src/stories/tab-list-utilities/tab-list-utilities-page.tsx
@@ -58,7 +58,7 @@ export const FluentUiTabStylesPage = () => {
   return (
     <div className={layoutStyles.grid}>
       <TabListContext.Provider value={{ selectedTab, setSelectedTab }}>
-        <PageHeader className={layoutStyles.header} title="Vertical stepper" />
+        <PageHeader className={layoutStyles.header} title="Tablist utilities" />
         <div
           className={mergeClasses(
             layoutStyles.content,

--- a/examples/src/stories/tab-list-utilities/tab-list-utilities-page.tsx
+++ b/examples/src/stories/tab-list-utilities/tab-list-utilities-page.tsx
@@ -1,0 +1,110 @@
+import React, { createContext, useContext, useState } from "react";
+import {
+  makeStyles,
+  mergeClasses,
+  shorthands,
+  Tab,
+  TabList,
+  tokens,
+} from "@fluentui/react-components";
+import { PageHeader } from "../../components/page-header";
+import { useLayoutStyles, useScrollPageStyle } from "../../styles/page";
+import { SectionTitle } from "../../components/section-title";
+import { bundleIcon, HomeFilled, HomeRegular } from "@fluentui/react-icons";
+import { CodeBlock } from "../../components/code-block";
+import {
+  codeBlockStyled,
+  StyledTabListComponent,
+  TTabListComponent,
+} from "./tab-list-styled.";
+
+type TTabListContext = {
+  selectedTab: string;
+  setSelectedTab: (value: string) => void;
+};
+
+const TabListContext = createContext<TTabListContext | null>(null);
+export const useTabListContext = () => {
+  const context = useContext(TabListContext);
+  if (context === null) {
+    throw new Error("cant use context outside its provider");
+  }
+  return context;
+};
+
+const HomeIcon = bundleIcon(HomeFilled, HomeRegular);
+
+const useTabListUtilitiesStyles = makeStyles({
+  section: {
+    display: "flex",
+    flexDirection: "row",
+    flexWrap: "wrap",
+    ...shorthands.gap(tokens.spacingHorizontalXXL),
+  },
+  group: {
+    display: "flex",
+    alignItems: "flex-start",
+    flexDirection: "column",
+    ...shorthands.gap(tokens.spacingHorizontalXS),
+  },
+});
+
+export const FluentUiTabStylesPage = () => {
+  const styles = useTabListUtilitiesStyles();
+  const scrollPageStyle = useScrollPageStyle();
+  const layoutStyles = useLayoutStyles();
+  const [selectedTab, setSelectedTab] = useState("tab1");
+
+  return (
+    <div className={layoutStyles.grid}>
+      <TabListContext.Provider value={{ selectedTab, setSelectedTab }}>
+        <PageHeader className={layoutStyles.header} title="Vertical stepper" />
+        <div
+          className={mergeClasses(
+            layoutStyles.content,
+            layoutStyles.sections,
+            scrollPageStyle
+          )}
+        >
+          <div className={styles.section}>
+            <div className={styles.group}>
+              <SectionTitle title={"TabList default"} />
+              <TabListComponent />
+              <TabListComponent withText={false} />
+              <TabListComponent vertical />
+              <TabListComponent withText={false} vertical />
+            </div>
+
+            <div className={styles.group}>
+              <SectionTitle title={"TabList styled tabs"} />
+              <StyledTabListComponent />
+              <StyledTabListComponent withText={false} />
+              <StyledTabListComponent vertical />
+              <StyledTabListComponent withText={false} vertical />
+
+              <CodeBlock codeString={codeBlockStyled} title={"code"} />
+            </div>
+          </div>
+        </div>
+      </TabListContext.Provider>
+    </div>
+  );
+};
+
+function TabListComponent({ withText = true, ...props }: TTabListComponent) {
+  const { selectedTab, setSelectedTab } = useTabListContext();
+  return (
+    <TabList
+      selectedValue={selectedTab}
+      defaultSelectedValue={selectedTab}
+      onTabSelect={(_, { value }) => {
+        setSelectedTab(value as unknown as string);
+      }}
+      {...props}
+    >
+      <Tab icon={<HomeIcon />} value="tab1">{withText && "First Tab"}</Tab>
+      <Tab icon={<HomeIcon />} value="tab2">{withText && "First Tab"}</Tab>
+      <Tab icon={<HomeIcon />} value="tab3">{withText && "First Tab"}</Tab>
+    </TabList>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -288,6 +292,9 @@ importers:
       react-router-dom:
         specifier: 6.20.1
         version: 6.20.1(react-dom@17.0.2)(react@17.0.2)
+      react-syntax-highlighter:
+        specifier: 15.5.0
+        version: 15.5.0(react@17.0.2)
       scheduler:
         specifier: 0.23.0
         version: 0.23.0
@@ -307,6 +314,9 @@ importers:
       '@types/react-dom':
         specifier: ^17.0.21
         version: 17.0.21
+      '@types/react-syntax-highlighter':
+        specifier: 15.5.11
+        version: 15.5.11
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -377,6 +387,9 @@ importers:
       '@fluentui/react-components':
         specifier: ^9.43.2
         version: 9.43.2(@types/react-dom@18.2.18)(@types/react@18.2.24)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.2)
+      '@fluentui/react-icons':
+        specifier: ^2.0.224
+        version: 2.0.224(react@18.2.0)
     devDependencies:
       '@types/react':
         specifier: ^18.2.24
@@ -6696,6 +6709,12 @@ packages:
     resolution: {integrity: sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==}
     dev: true
 
+  /@types/hast@2.3.10:
+    resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
+    dependencies:
+      '@types/unist': 2.0.10
+    dev: false
+
   /@types/istanbul-lib-coverage@2.0.6:
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
     dev: true
@@ -6745,6 +6764,12 @@ packages:
     dependencies:
       '@types/react': 18.2.24
 
+  /@types/react-syntax-highlighter@15.5.11:
+    resolution: {integrity: sha512-ZqIJl+Pg8kD+47kxUjvrlElrraSUrYa4h0dauY/U/FTUuprSCqvUj+9PNQNQzVc6AJgIWUUxn87/gqsMHNbRjw==}
+    dependencies:
+      '@types/react': 18.2.24
+    dev: true
+
   /@types/react@17.0.67:
     resolution: {integrity: sha512-zE76EIJ0Y58Oy9yDX/9csb/NuKjt0Eq2YgWb/8Wxo91YmuLzzbyiRoaqJE9h8iDlsT7n35GdpoLomHlaB1kFbg==}
     dependencies:
@@ -6765,6 +6790,10 @@ packages:
   /@types/semver@7.5.6:
     resolution: {integrity: sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==}
     dev: true
+
+  /@types/unist@2.0.10:
+    resolution: {integrity: sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==}
+    dev: false
 
   /@typescript-eslint/eslint-plugin@5.53.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@4.5.5):
     resolution: {integrity: sha512-alFpFWNucPLdUOySmXCJpzr6HKC3bu7XooShWM+3w/EL6J2HIoB2PFxpLnq4JauWVk6DiVeNKzQlFEaE+X9sGw==}
@@ -7579,6 +7608,18 @@ packages:
       tslib: 2.6.2
     dev: true
 
+  /character-entities-legacy@1.1.4:
+    resolution: {integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==}
+    dev: false
+
+  /character-entities@1.2.4:
+    resolution: {integrity: sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==}
+    dev: false
+
+  /character-reference-invalid@1.1.4:
+    resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
+    dev: false
+
   /check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
     dependencies:
@@ -7670,6 +7711,10 @@ packages:
     dependencies:
       delayed-stream: 1.0.0
     dev: true
+
+  /comma-separated-tokens@1.0.8:
+    resolution: {integrity: sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==}
+    dev: false
 
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -8960,6 +9005,12 @@ packages:
       reusify: 1.0.4
     dev: true
 
+  /fault@1.0.4:
+    resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
+    dependencies:
+      format: 0.2.2
+    dev: false
+
   /file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -9067,6 +9118,11 @@ packages:
       combined-stream: 1.0.8
       mime-types: 2.1.35
     dev: true
+
+  /format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
+    dev: false
 
   /fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -9375,12 +9431,30 @@ packages:
     dependencies:
       function-bind: 1.1.2
 
+  /hast-util-parse-selector@2.2.5:
+    resolution: {integrity: sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==}
+    dev: false
+
+  /hastscript@6.0.0:
+    resolution: {integrity: sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==}
+    dependencies:
+      '@types/hast': 2.3.10
+      comma-separated-tokens: 1.0.8
+      hast-util-parse-selector: 2.2.5
+      property-information: 5.6.0
+      space-separated-tokens: 1.1.5
+    dev: false
+
   /header-case@2.0.4:
     resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
     dependencies:
       capital-case: 1.0.4
       tslib: 2.6.2
     dev: true
+
+  /highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+    dev: false
 
   /homedir-polyfill@1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
@@ -9495,6 +9569,17 @@ packages:
       side-channel: 1.0.4
     dev: true
 
+  /is-alphabetical@1.0.4:
+    resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
+    dev: false
+
+  /is-alphanumerical@1.0.4:
+    resolution: {integrity: sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==}
+    dependencies:
+      is-alphabetical: 1.0.4
+      is-decimal: 1.0.4
+    dev: false
+
   /is-arguments@1.1.1:
     resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
     engines: {node: '>= 0.4'}
@@ -9553,6 +9638,10 @@ packages:
       has-tostringtag: 1.0.0
     dev: true
 
+  /is-decimal@1.0.4:
+    resolution: {integrity: sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==}
+    dev: false
+
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -9594,6 +9683,10 @@ packages:
     dependencies:
       is-extglob: 2.1.1
     dev: true
+
+  /is-hexadecimal@1.0.4:
+    resolution: {integrity: sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==}
+    dev: false
 
   /is-map@2.0.2:
     resolution: {integrity: sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==}
@@ -9963,6 +10056,13 @@ packages:
     dependencies:
       tslib: 2.6.2
     dev: true
+
+  /lowlight@1.20.0:
+    resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
+    dependencies:
+      fault: 1.0.4
+      highlight.js: 10.7.3
+    dev: false
 
   /lru-cache@10.1.0:
     resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
@@ -10390,6 +10490,17 @@ packages:
       callsites: 3.1.0
     dev: true
 
+  /parse-entities@2.0.0:
+    resolution: {integrity: sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==}
+    dependencies:
+      character-entities: 1.2.4
+      character-entities-legacy: 1.1.4
+      character-reference-invalid: 1.1.4
+      is-alphanumerical: 1.0.4
+      is-decimal: 1.0.4
+      is-hexadecimal: 1.0.4
+    dev: false
+
   /parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
@@ -10541,6 +10652,16 @@ packages:
       react-is: 18.2.0
     dev: true
 
+  /prismjs@1.27.0:
+    resolution: {integrity: sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /prismjs@1.29.0:
+    resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
+    engines: {node: '>=6'}
+    dev: false
+
   /process-nextick-args@1.0.7:
     resolution: {integrity: sha512-yN0WQmuCX63LP/TMvAg31nvT6m4vDqJEiiv2CAZqWOGNWutc9DfDk1NPYYmKUFmaVM2UwDowH4u5AHWYP/jxKw==}
     dev: true
@@ -10555,6 +10676,12 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  /property-information@5.6.0:
+    resolution: {integrity: sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==}
+    dependencies:
+      xtend: 4.0.2
+    dev: false
 
   /psl@1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
@@ -10638,6 +10765,19 @@ packages:
     dependencies:
       '@remix-run/router': 1.13.1
       react: 17.0.2
+    dev: false
+
+  /react-syntax-highlighter@15.5.0(react@17.0.2):
+    resolution: {integrity: sha512-+zq2myprEnQmH5yw6Gqc8lD55QHnpKaU8TOcFeC/Lg/MQSs8UknEA0JC4nTZGFAXC2J2Hyj/ijJ7NlabyPi2gg==}
+    peerDependencies:
+      react: '>= 0.14.0'
+    dependencies:
+      '@babel/runtime': 7.23.7
+      highlight.js: 10.7.3
+      lowlight: 1.20.0
+      prismjs: 1.29.0
+      react: 17.0.2
+      refractor: 3.6.0
     dev: false
 
   /react-transition-group@4.4.5(react-dom@17.0.2)(react@17.0.2):
@@ -10739,6 +10879,14 @@ packages:
       globalthis: 1.0.3
       which-builtin-type: 1.1.3
     dev: true
+
+  /refractor@3.6.0:
+    resolution: {integrity: sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==}
+    dependencies:
+      hastscript: 6.0.0
+      parse-entities: 2.0.0
+      prismjs: 1.27.0
+    dev: false
 
   /regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
@@ -11090,6 +11238,10 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /space-separated-tokens@1.1.5:
+    resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
+    dev: false
 
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -12158,6 +12310,11 @@ packages:
     deprecated: Deprecated due to CVE-2021-21366 resolved in 0.5.0
     dev: true
 
+  /xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+    dev: false
+
   /y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
     dev: true
@@ -12280,7 +12437,6 @@ packages:
   file:tools:
     resolution: {directory: tools, type: directory}
     name: tools
-    version: 8.7.1
     hasBin: true
     dependencies:
       cmd-ts: 0.13.0
@@ -12288,7 +12444,3 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/styles/package.json
+++ b/styles/package.json
@@ -37,6 +37,7 @@
   },
   "peerDependencies": {
     "@fluentui/react-components": "^9.43.2",
+    "@fluentui/react-icons": "^2.0.224",
     "react": ">=16.8.0 <19.0.0"
   },
   "packageManager": "pnpm@8.1.0",

--- a/styles/src/index.ts
+++ b/styles/src/index.ts
@@ -1,2 +1,4 @@
 export * from "./static/static.styles";
+export * from "./tab-list/tab-list.styles";
+export * from "./tab-list/tab.styles";
 export * from "./table/table.styles";

--- a/styles/src/tab-list/tab-list.styles.ts
+++ b/styles/src/tab-list/tab-list.styles.ts
@@ -1,0 +1,12 @@
+import { makeStyles, tokens } from "@fluentui/react-components";
+
+export const useTabListStyles = makeStyles({
+  root: {
+    display: "flex",
+    columnGap: tokens.spacingHorizontalXS,
+  },
+  vertical: {
+    flexDirection: "column",
+    rowGap: tokens.spacingVerticalXS,
+  },
+});

--- a/styles/src/tab-list/tab-list.styles.ts
+++ b/styles/src/tab-list/tab-list.styles.ts
@@ -1,6 +1,6 @@
-import { makeStyles, tokens } from "@fluentui/react-components";
+import { makeStyles, mergeClasses, tokens } from "@fluentui/react-components";
 
-export const useTabListStyles = makeStyles({
+const useStyles = makeStyles({
   root: {
     display: "flex",
     columnGap: tokens.spacingHorizontalXS,
@@ -10,3 +10,9 @@ export const useTabListStyles = makeStyles({
     rowGap: tokens.spacingVerticalXS,
   },
 });
+
+export const useTabListStyles = ({ vertical }: { vertical?: boolean }) => {
+  const styles = useStyles();
+  const rootStyle = mergeClasses(styles.root, vertical && styles.vertical);
+  return { styles, rootStyle };
+};

--- a/styles/src/tab-list/tab.styles.ts
+++ b/styles/src/tab-list/tab.styles.ts
@@ -1,0 +1,26 @@
+import { makeStyles, tokens } from "@fluentui/react-components";
+
+import {
+  iconFilledClassName,
+  iconRegularClassName,
+} from "@fluentui/react-icons";
+
+export const useTabStyles = makeStyles({
+  root: {
+    [`& .${iconFilledClassName}`]: {
+      color: tokens.colorNeutralForeground1,
+    },
+    [`& .${iconRegularClassName}`]: {
+      color: tokens.colorNeutralForeground1,
+    },
+    "&:hover": {
+      backgroundColor: tokens.colorSubtleBackgroundHover,
+    },
+  },
+  selected: {
+    backgroundColor: tokens.colorSubtleBackgroundSelected,
+    "&:hover": {
+      backgroundColor: tokens.colorSubtleBackgroundSelected,
+    },
+  },
+});

--- a/styles/src/tab-list/tab.styles.ts
+++ b/styles/src/tab-list/tab.styles.ts
@@ -1,11 +1,11 @@
-import { makeStyles, tokens } from "@fluentui/react-components";
+import { makeStyles, mergeClasses, tokens } from "@fluentui/react-components";
 
 import {
   iconFilledClassName,
   iconRegularClassName,
 } from "@fluentui/react-icons";
 
-export const useTabStyles = makeStyles({
+const useStyles = makeStyles({
   root: {
     [`& .${iconFilledClassName}`]: {
       color: tokens.colorNeutralForeground1,
@@ -24,3 +24,9 @@ export const useTabStyles = makeStyles({
     },
   },
 });
+
+export const useTabStyles = ({ selected }: { selected?: boolean }) => {
+  const styles = useStyles();
+  const rootStyle = mergeClasses(styles.root, selected && styles.selected);
+  return { styles, rootStyle };
+};


### PR DESCRIPTION
Exposes some new styles that can be used when styling fluent tablist, also added to example page with codeblock
<img width="970" alt="image" src="https://github.com/AxisCommunications/fluent-components/assets/105843747/18265bc7-a406-4f66-9255-286494359940">
