### PR TITLE
fix(slider): snap to mark

### DIFF
--- a/components/slider/src/range-slider.spec.tsx
+++ b/components/slider/src/range-slider.spec.tsx
@@ -130,6 +130,34 @@ describe("range-slider", () => {
 
       expect(onChangeCommitted).toHaveBeenCalledWith({ value: [40, 100] });
     });
+
+    it("should snap to closest mark", () => {
+      const onChange = vi.fn();
+      const onChangeCommitted = vi.fn();
+      const { getByTestId } = render(
+        <RangeSlider
+          title="Range Slider"
+          min={0}
+          max={100}
+          onChange={onChange}
+          onChangeCommitted={onChangeCommitted}
+          marks={[
+            { value: 20, label: <span data-testid="mark">20</span> },
+            { value: 40, label: "40" },
+            { value: 60, label: "60" },
+          ]}
+          data-testid="slider-root"
+        />
+      );
+
+      const mark: HTMLElement = getByTestId("mark");
+      getControlRoot(getByTestId("slider-root"));
+      fireEvent.mouseDown(mark, { button: 0, clientX: 29 });
+      fireEvent.mouseUp(mark, { button: 0, clientX: 29 });
+
+      expect(onChange).toHaveBeenCalledWith({ value: [20] });
+      expect(onChangeCommitted).toHaveBeenCalledWith({ value: [20] });
+    });
   });
 
   describe("keyboard interaction", () => {

--- a/examples/src/stories/slider/examples/range-slider-with-streps-and-marks-example.tsx
+++ b/examples/src/stories/slider/examples/range-slider-with-streps-and-marks-example.tsx
@@ -1,0 +1,39 @@
+import { RangeSlider } from "@axiscommunications/fluent-slider";
+import React from "react";
+
+export function WithStepsAndMarksRangeSliderExample() {
+  return (
+    <RangeSlider
+      min={0}
+      max={100}
+      title="Range Slider with steps and marks"
+      defaultValue={[50, 75]}
+      marks={[
+        { value: 50, label: "50" },
+        { value: 75, label: "75" },
+      ]}
+      step={25}
+    />
+  );
+}
+
+export const WithStepsAndMarksRangeSliderExampleAsString = `
+import { RangeSlider } from "@axiscommunications/fluent-slider";
+import React from "react";
+
+export function WithStepsAndMarksRangeSliderExample() {
+  return (
+    <RangeSlider
+      min={0}
+      max={100}
+      title="Range Slider with steps and marks"
+      defaultValue={[50, 75]}
+      marks={[
+        { value: 50, label: "50" },
+        { value: 75, label: "75" },
+      ]}
+      step={25}
+    />
+  )
+}
+`;

--- a/examples/src/stories/slider/slider-page.tsx
+++ b/examples/src/stories/slider/slider-page.tsx
@@ -51,6 +51,10 @@ import {
   WithStepsSliderExample,
   WithStepsSliderExampleAsString,
 } from "./examples/with-steps-example";
+import {
+  WithStepsAndMarksRangeSliderExample,
+  WithStepsAndMarksRangeSliderExampleAsString,
+} from "./examples/range-slider-with-streps-and-marks-example";
 
 const useStyles = makeStyles({
   example: {
@@ -88,6 +92,12 @@ const examples: pageData[] = [
     anchor: "WithStepsSliderExample",
     example: <WithStepsSliderExample />,
     codeString: WithStepsSliderExampleAsString,
+  },
+  {
+    title: "With steps and marks",
+    anchor: "WithStepsAndMarksSliderExample",
+    example: <WithStepsAndMarksRangeSliderExample />,
+    codeString: WithStepsAndMarksRangeSliderExampleAsString,
   },
   {
     title: "Stepping to marks",


### PR DESCRIPTION
### Describe your changes

- When a mark is the target of a click event, the slider will now snap to the value of the closest mark and not the specific clientX value.
-  Add example to slider page where both steps and marks are combined

### Issue ticket number and link

- N/A

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
