### PR TITLE
fix(topbar): application drawer style updates

### DIFF
--- a/components/topbar/src/application-drawer.styles.ts
+++ b/components/topbar/src/application-drawer.styles.ts
@@ -35,14 +35,13 @@ export const useApplicationDrawrStyles = makeStyles({
     ),
   },
   drawerTriggerApplication: {
-    fontSize: "1.8em",
     display: "flex",
-    flexDirection: "row",
     alignItems: "center",
     ...shorthands.gap(tokens.spacingHorizontalS),
     ...shorthands.padding(tokens.spacingVerticalXS, tokens.spacingHorizontalM),
   },
   drawerTriggerApplicationIcon: {
+    display: "flex",
     color: tokens.colorNeutralForeground2,
     "&:hover": {
       color: tokens.colorNeutralForeground2BrandHover,
@@ -55,14 +54,16 @@ export const useApplicationDrawrStyles = makeStyles({
     color: tokens.colorNeutralForeground2,
   },
   applicationGroupTitle: {
-    fontSize: "1.4em",
     display: "flex",
-    flexDirection: "row",
     alignItems: "center",
     ...shorthands.gap(tokens.spacingHorizontalS),
-    ...shorthands.padding(tokens.spacingVerticalXS, tokens.spacingHorizontalS),
+    paddingTop: tokens.spacingVerticalS,
+    paddingBottom: tokens.spacingVerticalMNudge,
+    paddingRight: tokens.spacingHorizontalS,
+    paddingLeft: tokens.spacingHorizontalS,
   },
   applicationGroupTitleIcon: {
+    display: "flex",
     color: tokens.colorNeutralForeground2,
   },
   applicationGroupTitleText: {
@@ -76,7 +77,7 @@ export const useApplicationDrawrStyles = makeStyles({
     flexDirection: "column",
     width: "100%",
     ...shorthands.gap(tokens.spacingVerticalS),
-    paddingTop: tokens.spacingVerticalXXXL,
+    paddingTop: "48px",
   },
   contentGroup: {
     display: "flex",


### PR DESCRIPTION
### Describe your changes

Minor style updates to application drawer
Left side before, right side after. (Just some more space...)
(And better icon-text-alignment, but that is not really visible in the example, but looks better with poptop)
<img width="666" alt="image" src="https://github.com/AxisCommunications/fluent-components/assets/67627784/2121c1b8-7e6a-4686-aa4c-235df28c6552">


### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
