### PR TITLE
fix(topbar): do not use ToggleButton in drawer

### DIFF
--- a/components/topbar/src/application-drawer.styles.ts
+++ b/components/topbar/src/application-drawer.styles.ts
@@ -105,6 +105,10 @@ export const useApplicationDrawrStyles = makeStyles({
     justifyContent: "flex-start",
     paddingLeft: tokens.spacingHorizontalSNudge,
   },
+  contentButtonChecked: {
+    color: tokens.colorNeutralForeground2Selected,
+    backgroundColor: tokens.colorSubtleBackgroundSelected,
+  },
   linkWrapper: {
     display: "flex",
     justifyContent: "flex-end",

--- a/components/topbar/src/application-drawer.tsx
+++ b/components/topbar/src/application-drawer.tsx
@@ -13,7 +13,6 @@ import {
   DrawerHeader,
   Link,
   mergeClasses,
-  ToggleButton,
   tokens,
 } from "@fluentui/react-components";
 import { useApplicationDrawrStyles as useApplicationDrawerStyles } from "./application-drawer.styles";
@@ -154,10 +153,12 @@ const SingleApplication = ({
   const styles = useApplicationDrawerStyles();
 
   return (
-    <ToggleButton
-      checked={application.id === currentSelectionId}
+    <Button
       data-testid={`application-drawer-item-${application.id}`}
-      className={styles.contentButton}
+      className={mergeClasses(
+        styles.contentButton,
+        application.id === currentSelectionId && styles.contentButtonChecked
+      )}
       appearance="subtle"
       icon={iconConverter(
         application.icon,
@@ -169,7 +170,7 @@ const SingleApplication = ({
       <Body1 className={styles.applicationButton}>
         {application.label}
       </Body1>
-    </ToggleButton>
+    </Button>
   );
 };
 


### PR DESCRIPTION
### Describe your changes

Replace ToggleButton with regular Button in drawer to not get yellow icons in later Fluent versions.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
