### PR TITLE
Fix topbar types

### DIFF
--- a/components/topbar/package.json
+++ b/components/topbar/package.json
@@ -23,7 +23,8 @@
     "lib"
   ],
   "scripts": {
-    "build": "pnpm build:cjs && pnpm build:esm",
+    "prebuild": "pnpm run -C ../../icons build",
+    "build": "pnpm prebuild && pnpm build:cjs && pnpm build:esm",
     "build:cjs": "tsc --module commonjs --outDir lib/cjs",
     "build:esm": "tsc",
     "check:unused-deps": "depcheck . --config=depcheck.yml",

--- a/components/topbar/src/translation-context.ts
+++ b/components/topbar/src/translation-context.ts
@@ -12,7 +12,12 @@ export type Translations = { readonly [key in TranslationKey]: string };
 export type TranslationFn = (key: keyof Translations) => string;
 export type TranslateLocaleFn = (lc: string | undefined) => string;
 
-export const TranslationContext = createContext<
+export const TranslationContext: React.Context<
+  {
+    readonly t: TranslationFn;
+    readonly tLocale: TranslateLocaleFn;
+  } | undefined
+> = createContext<
   { readonly t: TranslationFn; readonly tLocale: TranslateLocaleFn } | undefined
 >(undefined);
 

--- a/components/topbar/tsconfig.json
+++ b/components/topbar/tsconfig.json
@@ -2,9 +2,7 @@
   "extends": "./tsconfig.src.json",
   "compilerOptions": {
     "types": ["vitest/globals"],
-    "outDir": "lib",
-    "declaration": false,
-    "declarationMap": false
+    "outDir": "lib"
   },
   "include": ["src"],
   "exclude": ["vitest.config.ts"]


### PR DESCRIPTION
### Describe your changes

After the alignment of react version, the exported types in topbar was broken.
This fixes the types.
Also, a prebuild step is added for topbar as it requires icons to be build.


### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
