### PR TITLE
fix(topbar): make language menu look ok for single language

### DIFF
--- a/components/topbar/src/profile-language-submenu.styles.ts
+++ b/components/topbar/src/profile-language-submenu.styles.ts
@@ -4,7 +4,7 @@ export const useProfileLanguageSubmenuStyles = makeStyles({
   languageSelection: {
     overflowY: "auto",
     overflowX: "hidden",
-    minHeight: "60px",
+    minHeight: "32px",
     maxHeight: "30vh",
   },
 });


### PR DESCRIPTION
### Describe your changes

Minor update to topbar language selector so that it looks better when only one language is supported.
Before:
<img width="381" alt="image" src="https://github.com/AxisCommunications/fluent-components/assets/67627784/7b3421f2-42ac-4424-82e9-c34c8e135666">


After:
<img width="347" alt="image" src="https://github.com/AxisCommunications/fluent-components/assets/67627784/1f28b723-8da9-4b17-a72b-f94164e4700f">



### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
