### PR TITLE
fix(styles): update scrollbar static styles

### DIFF
--- a/styles/src/static/static.styles.ts
+++ b/styles/src/static/static.styles.ts
@@ -2,18 +2,20 @@ import { makeStaticStyles, tokens } from "@fluentui/react-components";
 
 const scrollbarColor = tokens.colorScrollbarOverlay;
 export const useScrollStaticStyles = makeStaticStyles({
-  "*": {
+  "@-moz-document url-prefix() {*": {
     // Firefox
+    // Scrollbar styling is amazingly complex. Read more here:
+    // https://stackoverflow.com/questions/6165472/custom-css-scrollbar-for-firefox
     scrollbarWidth: "thin",
     scrollbarColor: `${scrollbarColor} transparent`,
   },
   "*::-webkit-scrollbar": {
-    width: tokens.spacingHorizontalS,
-    height: tokens.spacingVerticalS,
+    width: tokens.spacingHorizontalSNudge,
+    height: tokens.spacingHorizontalSNudge,
   },
   "*::-webkit-scrollbar-thumb": {
     background: scrollbarColor,
-    borderRadius: tokens.borderRadiusLarge,
+    borderRadius: tokens.borderRadiusXLarge,
   },
   "*::-webkit-scrollbar-track": {
     background: "none",


### PR DESCRIPTION
### Describe your changes

Was just going to adapt the width and radius of scrollbar according to mocks:
https://www.figma.com/file/wIqVR0DqSc15Ocb5cG8W3q/Design-Guides?type=design&node-id=503-8392&mode=design&t=KWE9O4H8LEXTB5am-0

Ran into a new interesting issue, where chrome now is affected by the general "scrollbarWidth" that is needed for styling firefox.
Found a solution in the last entry in this amazing thread:
https://stackoverflow.com/questions/6165472/custom-css-scrollbar-for-firefox

Tested on Mac in Chrome, Firefox and Safari.
Tested on Windows in Chrome, Firefox and Edge.
(It does not look exactly the same in all browsers, but it looks ok)

### Issue ticket number and link


### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
