### PR TITLE
chore: adjust story copy code button

### DIFF
--- a/examples/src/components/story/story-code-block-accordion.tsx
+++ b/examples/src/components/story/story-code-block-accordion.tsx
@@ -9,11 +9,18 @@ import {
 } from "@fluentui/react-components";
 import React from "react";
 import { StoryCodeBlock } from "./story-code-block";
+import { CopyButton } from "./story-code-copy";
 
 const useStyles = makeStyles({
   root: {
     backgroundColor: tokens.colorNeutralBackground1,
     ...shorthands.borderRadius(tokens.borderRadiusLarge),
+  },
+  title: {
+    width: "100%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
   },
 });
 
@@ -33,9 +40,14 @@ export const StoryCodeBlockAccordion = (
       defaultOpenItems={defaultOpen ? "1" : null}
     >
       <AccordionItem value="1">
-        <AccordionHeader>{title}</AccordionHeader>
+        <AccordionHeader>
+          <div className={styles.title}>
+            {title}
+            <CopyButton codeString={codeString} />
+          </div>
+        </AccordionHeader>
         <AccordionPanel>
-          <StoryCodeBlock codeString={codeString} />
+          <StoryCodeBlock codeString={codeString} canCopy={false} />
         </AccordionPanel>
       </AccordionItem>
     </Accordion>

--- a/examples/src/components/story/story-code-block.tsx
+++ b/examples/src/components/story/story-code-block.tsx
@@ -1,7 +1,7 @@
-import { Button, makeStyles, tokens } from "@fluentui/react-components";
-import { RectangleLandscapeHintCopyRegular } from "@fluentui/react-icons";
-import React, { useCallback } from "react";
+import { makeStyles, tokens } from "@fluentui/react-components";
+import React from "react";
 import SyntaxHighlighter from "react-syntax-highlighter";
+import { CopyButton } from "./story-code-copy";
 
 const useStyles = makeStyles({
   root: {
@@ -19,20 +19,13 @@ export const StoryCodeBlock = (
 ) => {
   const styles = useStyles();
 
-  const copyCode = useCallback(async () => {
-    await copyToClipboard(codeString);
-  }, []);
-
   return (
     <div className={styles.root}>
       {canCopy && (
-        <Button
-          onClick={copyCode}
+        <CopyButton
+          codeString={codeString}
           className={styles.copy}
-          icon={<RectangleLandscapeHintCopyRegular />}
-        >
-          copy snippet
-        </Button>
+        />
       )}
       <SyntaxHighlighter language="typescript">
         {codeString}
@@ -40,11 +33,3 @@ export const StoryCodeBlock = (
     </div>
   );
 };
-
-async function copyToClipboard(text: string): Promise<void> {
-  try {
-    await navigator.clipboard.writeText(text);
-  } catch (error) {
-    console.error("Error copying to clipboard:", error);
-  }
-}

--- a/examples/src/components/story/story-code-copy.tsx
+++ b/examples/src/components/story/story-code-copy.tsx
@@ -1,0 +1,71 @@
+import {
+  Button,
+  makeStyles,
+  mergeClasses,
+  tokens,
+  Tooltip,
+} from "@fluentui/react-components";
+import { RectangleLandscapeHintCopyFilled } from "@fluentui/react-icons";
+import React, { useCallback } from "react";
+
+const componentId = "copy";
+export const copyClassNames = {
+  root: componentId,
+};
+
+const useStyles = makeStyles({
+  root: {
+    "&:hover": {
+      color: tokens.colorBrandBackground,
+    },
+  },
+});
+
+type TUseCopyStyles = {
+  className?: string;
+};
+
+export function useCopyStyles({ className }: TUseCopyStyles) {
+  const styles = useStyles();
+  const rootStyle = mergeClasses(copyClassNames.root, styles.root, className);
+  return { styles, rootStyle };
+}
+
+type TCopy = {
+  codeString: string;
+  className?: string;
+};
+
+export function CopyButton({ className, codeString, ...rest }: TCopy) {
+  const { rootStyle } = useCopyStyles({ className });
+
+  const copyCode = useCallback(
+    async (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+      e.stopPropagation();
+      e.preventDefault();
+      await copyToClipboard(codeString);
+    },
+    []
+  );
+
+  return (
+    <Tooltip withArrow content={"copy codeblock"} relationship={"label"}>
+      <Button
+        className={rootStyle}
+        {...rest}
+        shape="circular"
+        onClick={copyCode}
+        icon={<RectangleLandscapeHintCopyFilled />}
+      >
+      </Button>
+    </Tooltip>
+  );
+}
+
+async function copyToClipboard(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (error) {
+    console.error("Error copying to clipboard:", error);
+  }
+}


### PR DESCRIPTION
Adjust copy code button for stories to be more easy to use and less "blocking" of code

copy-button now directly accessible from header and doesnt block example code as it somethimes did before
<img width="1004" alt="image" src="https://github.com/AxisCommunications/fluent-components/assets/105843747/ff0030b5-28f4-405a-ba5a-6e1b59f2c593">
