### PR TITLE
fix(styles): handle firefox style without warning in chrome

### DIFF
--- a/styles/src/static/static.styles.ts
+++ b/styles/src/static/static.styles.ts
@@ -1,13 +1,15 @@
 import { makeStaticStyles, tokens } from "@fluentui/react-components";
 
 const scrollbarColor = tokens.colorScrollbarOverlay;
+
+const isFirefox = window.navigator.userAgent.includes("Fire");
 export const useScrollStaticStyles = makeStaticStyles({
-  "@-moz-document url-prefix() {*": {
+  "*": {
     // Firefox
     // Scrollbar styling is amazingly complex. Read more here:
     // https://stackoverflow.com/questions/6165472/custom-css-scrollbar-for-firefox
-    scrollbarWidth: "thin",
-    scrollbarColor: `${scrollbarColor} transparent`,
+    scrollbarWidth: isFirefox ? "thin" : "unset",
+    scrollbarColor: isFirefox ? `${scrollbarColor} transparent` : "auto",
   },
   "*::-webkit-scrollbar": {
     width: tokens.spacingHorizontalSNudge,


### PR DESCRIPTION
### Describe your changes

New fix to the scroll conflicts with firefox and chrome.
There were browser warnings with the previous hack.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
