### PR TITLE
chore: remove scheduler from peerDependencies

### DIFF
--- a/components/slider/package.json
+++ b/components/slider/package.json
@@ -43,8 +43,7 @@
     "@fluentui/react-icons": "^2.0.233",
     "@fluentui/react-utilities": "^9.18.5",
     "react": ">=16.8.0 <19.0.0",
-    "react-dom": ">=16.8.0 <19.0.0",
-    "scheduler": "^0.20.0"
+    "react-dom": ">=16.8.0 <19.0.0"
   },
   "packageManager": "pnpm@8.1.0",
   "publishConfig": {

--- a/components/stepper/package.json
+++ b/components/stepper/package.json
@@ -41,8 +41,7 @@
     "@fluentui/react-icons": "^2.0.233",
     "@fluentui/react-utilities": "^9.18.5",
     "react": ">=16.8.0 <19.0.0",
-    "react-dom": ">=16.8.0 <19.0.0",
-    "scheduler": "^0.20.0"
+    "react-dom": ">=16.8.0 <19.0.0"
   },
   "packageManager": "pnpm@8.1.0",
   "publishConfig": {

--- a/components/topbar/package.json
+++ b/components/topbar/package.json
@@ -51,8 +51,7 @@
     "@fluentui/react-icons": "^2.0.233",
     "@fluentui/react-utilities": "^9.18.5",
     "react": ">=16.8.0 <19.0.0",
-    "react-dom": ">=16.8.0 <19.0.0",
-    "scheduler": "^0.20.0"
+    "react-dom": ">=16.8.0 <19.0.0"
   },
   "dependencies": {
     "@axiscommunications/fluent-icons": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,16 +99,13 @@ importers:
     dependencies:
       '@fluentui/react-components':
         specifier: ^9.47.1
-        version: 9.47.1(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
+        version: 9.47.1(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)
       '@fluentui/react-icons':
         specifier: ^2.0.233
         version: 2.0.233(react@18.2.0)
       '@fluentui/react-utilities':
         specifier: ^9.18.5
         version: 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      scheduler:
-        specifier: ^0.20.0
-        version: 0.20.0
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.4.2
@@ -151,16 +148,13 @@ importers:
     dependencies:
       '@fluentui/react-components':
         specifier: ^9.47.1
-        version: 9.47.1(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
+        version: 9.47.1(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)
       '@fluentui/react-icons':
         specifier: ^2.0.233
         version: 2.0.233(react@18.2.0)
       '@fluentui/react-utilities':
         specifier: ^9.18.5
         version: 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      scheduler:
-        specifier: ^0.20.0
-        version: 0.20.0
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.4.2
@@ -203,16 +197,13 @@ importers:
         version: link:../../icons
       '@fluentui/react-components':
         specifier: ^9.47.1
-        version: 9.47.1(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
+        version: 9.47.1(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)
       '@fluentui/react-icons':
         specifier: ^2.0.233
         version: 2.0.233(react@18.2.0)
       '@fluentui/react-utilities':
         specifier: ^9.18.5
         version: 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      scheduler:
-        specifier: ^0.20.0
-        version: 0.20.0
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.4.2
@@ -451,10 +442,7 @@ importers:
     dependencies:
       '@fluentui/react-components':
         specifier: ^9.47.1
-        version: 9.47.1(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      scheduler:
-        specifier: ^0.20.0
-        version: 0.20.0
+        version: 9.47.1(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)
     devDependencies:
       '@types/node':
         specifier: ^20.11.18
@@ -961,32 +949,6 @@ packages:
       - scheduler
     dev: false
 
-  /@fluentui/react-accordion@9.3.46(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-bFOF/uoPYL4AUQEIKFTgx8WZgeC39Vw2FiL6A2A0km0Z9yBgWg7LLsF73/MbgoO0GjH8BvO/2ddpgdd433jIRw==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/react-aria': 9.10.2(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-context-selector': 9.1.56(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-icons': 2.0.233(react@18.2.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-tabster': 9.19.5(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
   /@fluentui/react-accordion@9.3.46(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0):
     resolution: {integrity: sha512-bFOF/uoPYL4AUQEIKFTgx8WZgeC39Vw2FiL6A2A0km0Z9yBgWg7LLsF73/MbgoO0GjH8BvO/2ddpgdd433jIRw==}
     peerDependencies:
@@ -1032,31 +994,6 @@ packages:
       '@swc/helpers': 0.5.3
       '@types/react': 18.2.65
       '@types/react-dom': 18.2.18
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
-  /@fluentui/react-alert@9.0.0-beta.114(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-ZA55Wf9ZNE2KfKnT9fDqvWqnAKgcrYwYIJoliG+pCLztCitwlv/XUKAWR/DkP02NpA2qEeaiY1D9k/Mwd1haIQ==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/react-avatar': 9.6.19(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-button': 9.3.73(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-icons': 2.0.233(react@18.2.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-tabster': 9.19.5(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -1150,34 +1087,6 @@ packages:
       '@swc/helpers': 0.5.3
       '@types/react': 18.2.65
       '@types/react-dom': 18.2.18
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
-  /@fluentui/react-avatar@9.6.19(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-3/8BBoPXNGfcuNVN4+bpwpd124CEdFEm9VKD6hQ6VmIHM6phBWnQc6J7djuKlZTw7B5UEeqEOEZgMJeGUx27SA==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/react-badge': 9.2.29(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-context-selector': 9.1.56(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-icons': 2.0.233(react@18.2.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-popover': 9.9.2(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-tabster': 9.19.5(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-tooltip': 9.4.21(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -1420,32 +1329,6 @@ packages:
       - scheduler
     dev: false
 
-  /@fluentui/react-checkbox@9.2.17(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-CnernbErbJZOeJAT6LflJlJt41n/nFReq6SHCnwrs6mt8NCZ6L5YU294kSPIHfLiJyRXjxUroDwQTsE+bwgKjw==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/react-field': 9.1.58(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-icons': 2.0.233(react@18.2.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-label': 9.1.66(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-tabster': 9.19.5(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
   /@fluentui/react-checkbox@9.2.17(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0):
     resolution: {integrity: sha512-CnernbErbJZOeJAT6LflJlJt41n/nFReq6SHCnwrs6mt8NCZ6L5YU294kSPIHfLiJyRXjxUroDwQTsE+bwgKjw==}
     peerDependencies:
@@ -1496,36 +1379,6 @@ packages:
       '@swc/helpers': 0.5.3
       '@types/react': 18.2.65
       '@types/react-dom': 18.2.18
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
-  /@fluentui/react-combobox@9.9.3(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-wkA0a39zCMLmL6TVayRu3YppRzEjBeC+2OQzsM0A1ZH7Y/jRg/BxlIdJnrMVYrpLqcC3vGlPNrpsgVrvNmz25g==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/keyboard-keys': 9.0.7
-      '@fluentui/react-aria': 9.10.2(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-context-selector': 9.1.56(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-field': 9.1.58(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-icons': 2.0.233(react@18.2.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-portal': 9.4.18(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-positioning': 9.14.2(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-tabster': 9.19.5(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -1631,75 +1484,6 @@ packages:
       - scheduler
     dev: false
 
-  /@fluentui/react-components@9.47.1(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-GJ83GAy6++VA8CkGDEapua4PYnCBMn8aFYXszw2ck4Jy6ZShK3Sr0O0I81JWd7VDgCRrVKcMpAQy/sEWFutmxQ==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/react-accordion': 9.3.46(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-alert': 9.0.0-beta.114(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-aria': 9.10.2(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-avatar': 9.6.19(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-badge': 9.2.29(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-breadcrumb': 9.0.19(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-button': 9.3.73(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-card': 9.0.72(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-checkbox': 9.2.17(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-combobox': 9.9.3(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-dialog': 9.9.15(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-divider': 9.2.65(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-drawer': 9.1.9(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-field': 9.1.58(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-image': 9.1.62(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-infobutton': 9.0.0-beta.98(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-infolabel': 9.0.26(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-input': 9.4.68(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-label': 9.1.66(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-link': 9.2.15(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-menu': 9.13.4(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-message-bar': 9.0.24(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-overflow': 9.1.15(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-persona': 9.2.78(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-popover': 9.9.2(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-portal': 9.4.18(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-positioning': 9.14.2(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-progress': 9.1.68(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-provider': 9.13.16(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-radio': 9.2.12(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-rating': 9.0.1(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-select': 9.1.68(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-skeleton': 9.0.56(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-slider': 9.1.74(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-spinbutton': 9.2.68(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-spinner': 9.4.2(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-switch': 9.1.74(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-table': 9.11.15(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-tabs': 9.4.14(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-tabster': 9.19.5(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-tags': 9.1.3(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-text': 9.4.14(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-textarea': 9.3.68(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-toast': 9.3.35(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-toolbar': 9.1.75(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-tooltip': 9.4.21(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-tree': 9.4.35(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-virtualizer': 9.0.0-alpha.73(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
   /@fluentui/react-components@9.47.1(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0):
     resolution: {integrity: sha512-GJ83GAy6++VA8CkGDEapua4PYnCBMn8aFYXszw2ck4Jy6ZShK3Sr0O0I81JWd7VDgCRrVKcMpAQy/sEWFutmxQ==}
     peerDependencies:
@@ -1787,24 +1571,6 @@ packages:
       scheduler: 0.23.0
     dev: false
 
-  /@fluentui/react-context-selector@9.1.56(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-TzDYTvHRuOB3qKiIBB0NU4mwX/fuxW41I1O9yK7C5Dt4RsexNInGLf5HMxYHWufevDSFhRLuAN+ikTHUMkcNzw==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-      scheduler: '>=0.19.0 <=0.23.0'
-    dependencies:
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      scheduler: 0.20.0
-    dev: false
-
   /@fluentui/react-context-selector@9.1.56(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0):
     resolution: {integrity: sha512-TzDYTvHRuOB3qKiIBB0NU4mwX/fuxW41I1O9yK7C5Dt4RsexNInGLf5HMxYHWufevDSFhRLuAN+ikTHUMkcNzw==}
     peerDependencies:
@@ -1845,35 +1611,6 @@ packages:
       '@swc/helpers': 0.5.3
       '@types/react': 18.2.65
       '@types/react-dom': 18.2.18
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-transition-group: 4.4.5(react-dom@18.2.0)(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
-  /@fluentui/react-dialog@9.9.15(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-UVjU7ZKq9117A80GQ/cv+YH/Pql4bN8FH3/GbJd8qwOxtlzOWpN8DOu1mwrj5ahxt3b+tpYsmp1QrqX9nujhMA==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/keyboard-keys': 9.0.7
-      '@fluentui/react-aria': 9.10.2(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-context-selector': 9.1.56(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-icons': 2.0.233(react@18.2.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-portal': 9.4.18(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-tabster': 9.19.5(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-transition-group: 4.4.5(react-dom@18.2.0)(react@18.2.0)
@@ -1975,31 +1712,6 @@ packages:
       - scheduler
     dev: false
 
-  /@fluentui/react-drawer@9.1.9(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-5KzOVxRPFJa0oDnp+kfCYJezA4JxsQzporNSmVw/i3/w/L9hCJyOuzrI+ps36Xb3tYymaKsAemC4+NAvs4HD+w==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/react-dialog': 9.9.15(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-motion-preview': 0.5.17(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-tabster': 9.19.5(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
   /@fluentui/react-drawer@9.1.9(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0):
     resolution: {integrity: sha512-5KzOVxRPFJa0oDnp+kfCYJezA4JxsQzporNSmVw/i3/w/L9hCJyOuzrI+ps36Xb3tYymaKsAemC4+NAvs4HD+w==}
     peerDependencies:
@@ -2043,30 +1755,6 @@ packages:
       '@swc/helpers': 0.5.3
       '@types/react': 18.2.65
       '@types/react-dom': 18.2.18
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
-  /@fluentui/react-field@9.1.58(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-FrjgCdFgtlagga/HzHExdkqlgrLNRP2slPA62R2JP8ZorzR6zEmnYyC5+rUAVBY0OXv79Ky957urvJz+4rBBNA==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/react-context-selector': 9.1.56(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-icons': 2.0.233(react@18.2.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-label': 9.1.66(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -2172,31 +1860,6 @@ packages:
       - scheduler
     dev: false
 
-  /@fluentui/react-infobutton@9.0.0-beta.98(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-7IFrKpmv1PnTN7ZrisYE7qrsfY6bRTK5AVnsQVrBX9/6xkLe4ZE52cQtoAnTX1gMIgqDhgoOd/RTzTO07xxPiw==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/react-icons': 2.0.233(react@18.2.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-label': 9.1.66(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-popover': 9.9.2(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-tabster': 9.19.5(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
   /@fluentui/react-infobutton@9.0.0-beta.98(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0):
     resolution: {integrity: sha512-7IFrKpmv1PnTN7ZrisYE7qrsfY6bRTK5AVnsQVrBX9/6xkLe4ZE52cQtoAnTX1gMIgqDhgoOd/RTzTO07xxPiw==}
     peerDependencies:
@@ -2247,31 +1910,6 @@ packages:
       - scheduler
     dev: false
 
-  /@fluentui/react-infolabel@9.0.26(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-mvLRsiS0bP0mLokMmU8Aho8Wea4OE1vBvisuC2uwq584WyDyk8rxjyPNqFo0BrcgwHSB++bHcQpsF4keP1UVQQ==}
-    peerDependencies:
-      '@types/react': '>=16.8.0 <19.0.0'
-      '@types/react-dom': '>=16.8.0 <19.0.0'
-      react: '>=16.8.0 <19.0.0'
-      react-dom: '>=16.8.0 <19.0.0'
-    dependencies:
-      '@fluentui/react-icons': 2.0.233(react@18.2.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-label': 9.1.66(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-popover': 9.9.2(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-tabster': 9.19.5(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
   /@fluentui/react-infolabel@9.0.26(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0):
     resolution: {integrity: sha512-mvLRsiS0bP0mLokMmU8Aho8Wea4OE1vBvisuC2uwq584WyDyk8rxjyPNqFo0BrcgwHSB++bHcQpsF4keP1UVQQ==}
     peerDependencies:
@@ -2314,29 +1952,6 @@ packages:
       '@swc/helpers': 0.5.3
       '@types/react': 18.2.65
       '@types/react-dom': 18.2.18
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
-  /@fluentui/react-input@9.4.68(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-NCnHG/e17TkOW6L28nFQp654vTBvdlfzvpwSqKmzeeC7H71tweqdlgnaRnzyd58FOKe9fQ69bzk/TG9P3qiixg==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/react-field': 9.1.58(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -2492,35 +2107,6 @@ packages:
       - scheduler
     dev: false
 
-  /@fluentui/react-menu@9.13.4(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-dIcClcBMjxj1eBKHiCdTYI59nnldPQHv+e/JW2YxP6XecJVLa/zoxsMoiwor/uzU2JlGKzKNQj2CIDkok71ivw==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/keyboard-keys': 9.0.7
-      '@fluentui/react-aria': 9.10.2(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-context-selector': 9.1.56(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-icons': 2.0.233(react@18.2.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-portal': 9.4.18(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-positioning': 9.14.2(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-tabster': 9.19.5(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
   /@fluentui/react-menu@9.13.4(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0):
     resolution: {integrity: sha512-dIcClcBMjxj1eBKHiCdTYI59nnldPQHv+e/JW2YxP6XecJVLa/zoxsMoiwor/uzU2JlGKzKNQj2CIDkok71ivw==}
     peerDependencies:
@@ -2658,28 +2244,6 @@ packages:
       - scheduler
     dev: false
 
-  /@fluentui/react-overflow@9.1.15(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-oIHwP9jLP3vzUlPy2M8shzgwHSvIh3mhc2A5CPTyu+aU906NFV6EFEx03vy62Cof21Ux71KOpPTFTAX0tBQrAA==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/priority-overflow': 9.1.11
-      '@fluentui/react-context-selector': 9.1.56(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
   /@fluentui/react-overflow@9.1.15(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0):
     resolution: {integrity: sha512-oIHwP9jLP3vzUlPy2M8shzgwHSvIh3mhc2A5CPTyu+aU906NFV6EFEx03vy62Cof21Ux71KOpPTFTAX0tBQrAA==}
     peerDependencies:
@@ -2720,30 +2284,6 @@ packages:
       '@swc/helpers': 0.5.3
       '@types/react': 18.2.65
       '@types/react-dom': 18.2.18
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
-  /@fluentui/react-persona@9.2.78(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-pWpyTYtoV7y1vHZv/MMc+h6kbIh9jB69FMXjkNX2uUiEBq0e+RQlkDhivZv58t9y6S8ZqdPZEelJgbH8HfHekw==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/react-avatar': 9.6.19(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-badge': 9.2.29(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -2796,34 +2336,6 @@ packages:
       '@swc/helpers': 0.5.3
       '@types/react': 18.2.65
       '@types/react-dom': 18.2.18
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
-  /@fluentui/react-popover@9.9.2(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-F/7VTPZMVCY/dwqumzrp+wzRNTlsKJ9Gz1nmZPZuO7IMBC8XRIGkjqdjW7oW8SzIrRmOTkAvmsn4UfPL19spiw==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/keyboard-keys': 9.0.7
-      '@fluentui/react-aria': 9.10.2(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-context-selector': 9.1.56(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-portal': 9.4.18(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-positioning': 9.14.2(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-tabster': 9.19.5(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -2963,29 +2475,6 @@ packages:
       - scheduler
     dev: false
 
-  /@fluentui/react-progress@9.1.68(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-6DhpwhSc25dbWJL4DRxEzYw3NSzZkqkY6yJCdQIMwrUGd7Ju8f0wxZ8VdfZFSzJPnVDybU8IESO9kbXDsg5YfQ==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/react-field': 9.1.58(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
   /@fluentui/react-progress@9.1.68(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0):
     resolution: {integrity: sha512-6DhpwhSc25dbWJL4DRxEzYw3NSzZkqkY6yJCdQIMwrUGd7Ju8f0wxZ8VdfZFSzJPnVDybU8IESO9kbXDsg5YfQ==}
     peerDependencies:
@@ -3074,31 +2563,6 @@ packages:
       '@swc/helpers': 0.5.3
       '@types/react': 18.2.65
       '@types/react-dom': 18.2.18
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
-  /@fluentui/react-radio@9.2.12(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-V2FcDzojcqBQiy2sNdEt6Yj8QWoMM9DUvBvXuyjJawtsN5MlB3vkQlst2MpG0Fc1NQgrfnY73XkNAencwPWUYQ==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/react-field': 9.1.58(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-label': 9.1.66(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-tabster': 9.19.5(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -3196,30 +2660,6 @@ packages:
       - scheduler
     dev: false
 
-  /@fluentui/react-select@9.1.68(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-c5SBSuqWIqBHp5/3LMNIzk/KkIgb3tgJWqwQ0xQ9EYGFJLRbTG7iPE9JMeG/CmBa9zvb1WoFAaKnvdN5/vgSCQ==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/react-field': 9.1.58(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-icons': 2.0.233(react@18.2.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
   /@fluentui/react-select@9.1.68(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0):
     resolution: {integrity: sha512-c5SBSuqWIqBHp5/3LMNIzk/KkIgb3tgJWqwQ0xQ9EYGFJLRbTG7iPE9JMeG/CmBa9zvb1WoFAaKnvdN5/vgSCQ==}
     peerDependencies:
@@ -3279,29 +2719,6 @@ packages:
       - scheduler
     dev: false
 
-  /@fluentui/react-skeleton@9.0.56(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-oY+/ZB52dQ6cZ1ll9FE5rqdSQdfAAh2Huw4MxIucm0Oh44dX3gB0+QE3Ar1yb2izVKi7AXLor7EIPaRm1lk1/A==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/react-field': 9.1.58(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
   /@fluentui/react-skeleton@9.0.56(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0):
     resolution: {integrity: sha512-oY+/ZB52dQ6cZ1ll9FE5rqdSQdfAAh2Huw4MxIucm0Oh44dX3gB0+QE3Ar1yb2izVKi7AXLor7EIPaRm1lk1/A==}
     peerDependencies:
@@ -3343,30 +2760,6 @@ packages:
       '@swc/helpers': 0.5.3
       '@types/react': 18.2.65
       '@types/react-dom': 18.2.18
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
-  /@fluentui/react-slider@9.1.74(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-vEbgf0MRzEovwFpptjjX9b5Apq461Iwnro1hxQiQUPqFwVdZqj0OzCJuvuohnbvNlZdtwihGkJ76gIYwMQG4Ag==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/react-field': 9.1.58(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-tabster': 9.19.5(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -3416,31 +2809,6 @@ packages:
       '@swc/helpers': 0.5.3
       '@types/react': 18.2.65
       '@types/react-dom': 18.2.18
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
-  /@fluentui/react-spinbutton@9.2.68(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-NKJ5+Aix9l+YUBQ4Mf8z2cl5yb23QMRbsnK2IJfnDUHviRRPv2pvYu9hsBjHRBeCbrJWh3fBJhy4lA5kf9vWRg==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/keyboard-keys': 9.0.7
-      '@fluentui/react-field': 9.1.58(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-icons': 2.0.233(react@18.2.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -3540,32 +2908,6 @@ packages:
       - scheduler
     dev: false
 
-  /@fluentui/react-switch@9.1.74(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-mE+kHOVRXdHSvHVKGoV+8dXlm7nSpC3vVO1sDJW1KtYwE0eJ1a0DV8flfeHe4FW2ThADGIDThgiB/WJR+NwfYw==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/react-field': 9.1.58(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-icons': 2.0.233(react@18.2.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-label': 9.1.66(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-tabster': 9.19.5(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
   /@fluentui/react-switch@9.1.74(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0):
     resolution: {integrity: sha512-mE+kHOVRXdHSvHVKGoV+8dXlm7nSpC3vVO1sDJW1KtYwE0eJ1a0DV8flfeHe4FW2ThADGIDThgiB/WJR+NwfYw==}
     peerDependencies:
@@ -3622,36 +2964,6 @@ packages:
       - scheduler
     dev: false
 
-  /@fluentui/react-table@9.11.15(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-4dMDLmHvGuW2fezO5Mfau1V7K1/7/+rC3PbWMf9K1j6veoE19TIr3jqpoXvnwxQ3UWGmeyut3LhO97vOrPdwyg==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/keyboard-keys': 9.0.7
-      '@fluentui/react-aria': 9.10.2(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-avatar': 9.6.19(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-checkbox': 9.2.17(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-context-selector': 9.1.56(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-icons': 2.0.233(react@18.2.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-radio': 9.2.12(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-tabster': 9.19.5(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
   /@fluentui/react-table@9.11.15(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0):
     resolution: {integrity: sha512-4dMDLmHvGuW2fezO5Mfau1V7K1/7/+rC3PbWMf9K1j6veoE19TIr3jqpoXvnwxQ3UWGmeyut3LhO97vOrPdwyg==}
     peerDependencies:
@@ -3700,30 +3012,6 @@ packages:
       '@swc/helpers': 0.5.3
       '@types/react': 18.2.65
       '@types/react-dom': 18.2.18
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
-  /@fluentui/react-tabs@9.4.14(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-hXcgzQCnmHym5ERlitE1gWU974TT644034FUXoc4x4EoduLQ1FEebHRFZKajGeR+/gGHvBXXnbvdw6dNZwwJkw==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/react-context-selector': 9.1.56(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-tabster': 9.19.5(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -3823,33 +3111,6 @@ packages:
       - scheduler
     dev: false
 
-  /@fluentui/react-tags@9.1.3(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-gcoBdgESx9doPD1e6RcqCenZv4YEnHgV9tlAnRNYM13YEoAjAXtG8cD5vY5YUNYsS268IY79ZCBD7IV02G4aKQ==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/keyboard-keys': 9.0.7
-      '@fluentui/react-aria': 9.10.2(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-avatar': 9.6.19(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-icons': 2.0.233(react@18.2.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-tabster': 9.19.5(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
   /@fluentui/react-tags@9.1.3(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0):
     resolution: {integrity: sha512-gcoBdgESx9doPD1e6RcqCenZv4YEnHgV9tlAnRNYM13YEoAjAXtG8cD5vY5YUNYsS268IY79ZCBD7IV02G4aKQ==}
     peerDependencies:
@@ -3934,29 +3195,6 @@ packages:
       '@swc/helpers': 0.5.3
       '@types/react': 18.2.65
       '@types/react-dom': 18.2.18
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
-  /@fluentui/react-textarea@9.3.68(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-lMlNlVGFtM0tlqEnwEkSZGOoSQ6wDPaRF9sgqchJTduhVJNXFesibKDyBj970VZyQ6YmgLp+e1SGsbd9xAyRKA==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/react-field': 9.1.58(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -4072,33 +3310,6 @@ packages:
       - scheduler
     dev: false
 
-  /@fluentui/react-toolbar@9.1.75(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-gUhxzVUet2ersmbX6euFNq4sE7eu7i0wV8mnco+7Rcfh/jmMrRO5k5YfEO7S/1woDa88k3GnKd1JzNDHXUnTkw==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/react-button': 9.3.73(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-context-selector': 9.1.56(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-divider': 9.2.65(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-radio': 9.2.12(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-tabster': 9.19.5(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
   /@fluentui/react-toolbar@9.1.75(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0):
     resolution: {integrity: sha512-gUhxzVUet2ersmbX6euFNq4sE7eu7i0wV8mnco+7Rcfh/jmMrRO5k5YfEO7S/1woDa88k3GnKd1JzNDHXUnTkw==}
     peerDependencies:
@@ -4199,37 +3410,6 @@ packages:
       '@swc/helpers': 0.5.3
       '@types/react': 18.2.65
       '@types/react-dom': 18.2.18
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - scheduler
-    dev: false
-
-  /@fluentui/react-tree@9.4.35(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0):
-    resolution: {integrity: sha512-4NlV0xSaFKkjLietCaSS+WGoFoxUBIT2VqdYQDGseqNzo/z9V89rfygWpw6HJpNVdj/AyTJKGEGZhMlCN+VtRA==}
-    peerDependencies:
-      '@types/react': '>=16.14.0 <19.0.0'
-      '@types/react-dom': '>=16.9.0 <19.0.0'
-      react: '>=16.14.0 <19.0.0'
-      react-dom: '>=16.14.0 <19.0.0'
-    dependencies:
-      '@fluentui/keyboard-keys': 9.0.7
-      '@fluentui/react-aria': 9.10.2(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-avatar': 9.6.19(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-button': 9.3.73(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-checkbox': 9.2.17(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-context-selector': 9.1.56(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-icons': 2.0.233(react@18.2.0)
-      '@fluentui/react-jsx-runtime': 9.0.34(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-radio': 9.2.12(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.20.0)
-      '@fluentui/react-shared-contexts': 9.15.2(@types/react@18.2.65)(react@18.2.0)
-      '@fluentui/react-tabster': 9.19.5(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)
-      '@fluentui/react-theme': 9.1.19
-      '@fluentui/react-utilities': 9.18.5(@types/react@18.2.65)(react@18.2.0)
-      '@griffel/react': 1.5.20(react@18.2.0)
-      '@swc/helpers': 0.5.3
-      '@types/react': 18.2.65
-      '@types/react-dom': 18.2.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -8972,13 +8152,6 @@ packages:
     dependencies:
       xmlchars: 2.2.0
     dev: true
-
-  /scheduler@0.20.0:
-    resolution: {integrity: sha512-XegIgta1bIaz2LdaL6eg1GEcE42g0BY9qFXCqlZ/+s2MuEKfigFCW6DEGBlZzeVFlwDmVusrWEyFtBo4sbkkdA==}
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-    dev: false
 
   /scheduler@0.23.0:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}

--- a/theme/package.json
+++ b/theme/package.json
@@ -48,8 +48,7 @@
   "peerDependencies": {
     "@fluentui/react-components": "^9.47.1",
     "react": ">=16.8.0 <19.0.0",
-    "react-dom": ">=16.8.0 <19.0.0",
-    "scheduler": "^0.20.0"
+    "react-dom": ">=16.8.0 <19.0.0"
   },
   "packageManager": "pnpm@8.1.0",
   "publishConfig": {


### PR DESCRIPTION
### Describe your changes

@fluentui/react-components, @fluentui/react-icons nor @fluentui/react-utilities no longer has a scheduler (0.20.0) peerDepencency.

Only @fluentui/react-context-selector as only used by examples has a scheduler (>=0.19.0 <=0.23.0) peerDependency.

We should remove the peerDependency to avoid unnecessary dependencies/warnings.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
