### PR TITLE
fix(topbar): buildUrl utility function should not duplicate query parameters

### DIFF
--- a/components/topbar/src/context.spec.ts
+++ b/components/topbar/src/context.spec.ts
@@ -56,4 +56,26 @@ describe("topbar settings", () => {
     const urlWithSettings = buildUrlWithContext(url, searchParams);
     expect(urlWithSettings).toBe("https://app.my.axis.com/");
   });
+
+  it("serializer should not duplicate parameters", () => {
+    const url = "https://app.my.axis.com";
+    const searchParams = {
+      lang,
+      org,
+      theme,
+      rg,
+    };
+    const urlWithSettings = buildUrlWithContext(url, searchParams);
+    expect(urlWithSettings).toBe(
+      "https://app.my.axis.com/?lang=en&org=arn%3Aorganization%3A0000&theme=dark&rg=resourcegroup"
+    );
+
+    const updatedUrlWithSettings = buildUrlWithContext(
+      urlWithSettings,
+      searchParams
+    );
+    expect(updatedUrlWithSettings).toBe(
+      "https://app.my.axis.com/?lang=en&org=arn%3Aorganization%3A0000&theme=dark&rg=resourcegroup"
+    );
+  });
 });

--- a/components/topbar/src/context.ts
+++ b/components/topbar/src/context.ts
@@ -12,7 +12,7 @@ export function buildUrlWithContext(url: string, ctx: TopBarContext) {
   for (const key of topBarContextKeys) {
     const value = ctx[key];
     if (value !== undefined) {
-      urlWithSettings.searchParams.append(key, value);
+      urlWithSettings.searchParams.set(key, value);
     }
   }
   return urlWithSettings.href;


### PR DESCRIPTION
### Describe your changes

Updated buildUrlWithContext so it does not duplicate query parameters if called with known parameters.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
