### PR TITLE
custom theme colors

### DIFF
--- a/components/topbar/package.json
+++ b/components/topbar/package.json
@@ -23,7 +23,7 @@
     "lib"
   ],
   "scripts": {
-    "prebuild": "pnpm run -C ../../icons build",
+    "prebuild": "pnpm run -C ../../icons build && pnpm run -C ../../theme build ",
     "build": "pnpm prebuild && pnpm build:cjs && pnpm build:esm",
     "build:cjs": "tsc --module commonjs --outDir lib/cjs",
     "build:esm": "tsc",
@@ -47,6 +47,7 @@
     "vitest": "^0.34.6"
   },
   "peerDependencies": {
+    "@axiscommunications/fluent-theme": ">=9.0.0",
     "@fluentui/react-components": "^9.47.1",
     "@fluentui/react-icons": "^2.0.233",
     "@fluentui/react-utilities": "^9.18.5",
@@ -54,7 +55,8 @@
     "react-dom": ">=16.8.0 <19.0.0"
   },
   "dependencies": {
-    "@axiscommunications/fluent-icons": "workspace:*"
+    "@axiscommunications/fluent-icons": "workspace:*",
+    "@axiscommunications/fluent-theme": "workspace:*"
   },
   "packageManager": "pnpm@8.1.0",
   "publishConfig": {

--- a/components/topbar/src/application.styles.ts
+++ b/components/topbar/src/application.styles.ts
@@ -8,6 +8,7 @@ import {
   iconFilledClassName,
   iconRegularClassName,
 } from "@fluentui/react-icons";
+import { axisCustomTokens } from "@axiscommunications/fluent-theme";
 
 export const useApplicationStyles = makeStyles({
   headerLabel: {
@@ -92,20 +93,20 @@ export const useApplicationStyles = makeStyles({
     },
   },
   mySystemsMenuRectangle: {
-    color: "#CCEBF8",
-    backgroundColor: "#008DC6",
+    color: axisCustomTokens.axisCustomColorMySystemsForeground,
+    backgroundColor: axisCustomTokens.axisCustomColorMySystemsBackground,
   },
   myAxisMenuRectangle: {
-    color: "#FFF5D6",
-    backgroundColor: "#DFA001",
+    color: axisCustomTokens.axisCustomColorMyAxisForeground,
+    backgroundColor: axisCustomTokens.axisCustomColorMyAxisBackground,
   },
   myPartnersMenuRectangle: {
-    color: "#E8F4D9",
-    backgroundColor: "#7FB239",
+    color: axisCustomTokens.axisCustomColorMyProductsForeground,
+    backgroundColor: axisCustomTokens.axisCustomColorMyProductsBackground,
   },
   myBusinessMenuRectangle: {
-    color: "#F7CEE8",
-    backgroundColor: "#C10B7E",
+    color: axisCustomTokens.axisCustomColorMyBusinessForeground,
+    backgroundColor: axisCustomTokens.axisCustomColorMyBusinessBackground,
   },
   selectedAppLabel: {
     ...typographyStyles.body1Strong,

--- a/examples/src/stories/theme/components/color-tokens.tsx
+++ b/examples/src/stories/theme/components/color-tokens.tsx
@@ -16,7 +16,7 @@ export const colorTokensClassNames = {
 const useStyles = makeStyles({
   root: {
     display: "grid",
-    gridTemplateColumns: "max-content auto auto",
+    gridTemplateColumns: "2fr 1fr 1fr",
     ...shorthands.gap(tokens.spacingHorizontalXS),
     fontFamily: "monospace",
     "> :nth-child(1)": {
@@ -57,15 +57,59 @@ export function ColorTokens({ theme, filter, ...rest }: TColorTokens) {
       ],
     }));
 
+  const customColorTokens = Object.entries(light).filter(([token]) =>
+    token.startsWith("axisCustomColor")
+  ).map(([token, value]) => ({
+    token,
+    lightValue: value as string,
+    darkValue: (dark as unknown as Record<string, string>)[
+      token
+    ],
+  }));
+
+  const customUtilityTokens = Object.entries(light).filter(([token]) =>
+    token.startsWith("axisCustomUtility")
+  ).map(([token, value]) => ({
+    token,
+    lightValue: value as string,
+    darkValue: (dark as unknown as Record<string, string>)[
+      token
+    ],
+  }));
+
   const { rootStyle } = useColorTokensStyles();
 
   return (
-    <div data-testid={componentId} className={rootStyle} {...rest}>
-      <b>token</b>
-      <b>light</b>
-      <b>dark</b>
-      {tokens.map((args, i) => <ColorPalette key={i} {...args} />)}
-    </div>
+    <>
+      <div data-testid={componentId} className={rootStyle} {...rest}>
+        <b>token</b>
+        <b>light</b>
+        <b>dark</b>
+        {tokens.map((args, i) => <ColorPalette key={i} {...args} />)}
+      </div>
+      <div data-testid={componentId} className={rootStyle} {...rest}>
+        <b>custom color token</b>
+        <b>light</b>
+        <b>dark</b>
+        {customColorTokens.map((args, i) => (
+          <ColorPalette
+            key={i}
+            {...args}
+          />
+        ))}
+      </div>
+      <div data-testid={componentId} className={rootStyle} {...rest}>
+        <b>custom utility token</b>
+        <b>light</b>
+        <b>dark</b>
+        {customUtilityTokens.map((args, i) => (
+          <ColorPalette
+            key={i}
+            {...args}
+          />
+        ))}
+      </div>
+    </>
   );
 }
 

--- a/examples/src/stories/theme/theme-page.tsx
+++ b/examples/src/stories/theme/theme-page.tsx
@@ -48,10 +48,22 @@ export const ThemePage = () => {
 };
 
 export const themeCodeAsString = `
+import { makeStyles, FluentProvider } from "@fluentui/react-components";
 import {
   axisLightTheme,
   axisDarkTheme,
   axisBlueLightTheme,
   axisBlueDarkTheme,
 } from "@axiscommunications/fluent-theme";
+import { axisCustomTokens } from "@axiscommunications/fluent-theme";
+
+export const useApplicationStyles = makeStyles({
+  root: {
+    backgroundColor: axisCustomTokens.axisCustomColorMyBusinessBackground
+  }
+});
+
+<FluentProvider theme={axisDarkTheme}>
+  <App/>
+</FluentProvider>
 `;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
       '@axiscommunications/fluent-icons':
         specifier: workspace:*
         version: link:../../icons
+      '@axiscommunications/fluent-theme':
+        specifier: workspace:*
+        version: link:../../theme
       '@fluentui/react-components':
         specifier: ^9.47.1
         version: 9.47.1(@types/react-dom@18.2.8)(@types/react@18.2.65)(react-dom@18.2.0)(react@18.2.0)(scheduler@0.23.0)

--- a/theme/docs/README.md
+++ b/theme/docs/README.md
@@ -1,13 +1,12 @@
 # Theme - @axiscommunications/fluent-theme
 
-An Axis branded theme for Fluent UI v9.
-
+An Axis branded theme for Fluent UI v9. Extended with custom tokens.
 Axis themes in this package are consumed via `npm.pkg.github.com` as `@axiscommunications/fluent-theme`.
 
 ```tsx
 import React from "react";
 import { FluentProvider } from "@fluentui/react-components";
-import { axisDarkTheme } from "@axiscommunications/fluent-theme";
+import { axisDarkTheme, axisCustomTokens } from "@axiscommunications/fluent-theme";
 import { createRoot } from "react-dom/client";
 
 const container = document.getElementById("root");
@@ -16,11 +15,23 @@ const root = createRoot(container!);
 root.render(
   <React.StrictMode>
     <FluentProvider theme={axisDarkTheme}>
-      <App />
+      <App/>
     </FluentProvider>
   </React.StrictMode>
 );
 ```
+```tsx
+import React from "react";
+import { makeStyles } from "@fluentui/react-components";
+import { axisCustomTokens } from "@axiscommunications/fluent-theme";
+
+export const useApplicationStyles = makeStyles({
+  root: {
+    backgroundColor: axisCustomTokens.axisCustomColorMyBusinessBackground
+  }
+});
+```
+
 
 # Tokens
 

--- a/theme/src/index.ts
+++ b/theme/src/index.ts
@@ -27,7 +27,50 @@ export const brand: BrandVariants = {
   160: "#FFFCF1",
 };
 
-export const axisDarkTheme: Theme = {
+export type AxisCustomColorTokens = {
+  axisCustomColorMySystemsBackground: string;
+  axisCustomColorMySystemsForeground: string;
+  axisCustomColorMyAxisBackground: string;
+  axisCustomColorMyAxisForeground: string;
+  axisCustomColorMyBusinessBackground: string;
+  axisCustomColorMyBusinessForeground: string;
+  axisCustomColorMyProductsBackground: string;
+  axisCustomColorMyProductsForeground: string;
+};
+
+export type AxisCustomUtilityTokens = {
+  axisCustomUtilityThemeName:
+    | "axisDarkTheme"
+    | "axisLightTheme"
+    | "axisBlueDarkTheme"
+    | "axisBlueLightTheme";
+};
+
+export type AxisCustomTokens = AxisCustomColorTokens & AxisCustomUtilityTokens;
+export type AxisTheme = Theme & AxisCustomTokens;
+
+export const axisCustomTokens: Record<
+  keyof AxisCustomTokens,
+  string
+> = {
+  axisCustomColorMyAxisBackground: "var(--axisCustomColorMyAxisBackground)",
+  axisCustomColorMyAxisForeground: "var(--axisCustomColorMyAxisForeground)",
+  axisCustomColorMySystemsBackground:
+    "var(--axisCustomColorMySystemsBackground)",
+  axisCustomColorMySystemsForeground:
+    "var(--axisCustomColorMySystemsForeground)",
+  axisCustomColorMyBusinessBackground:
+    "var(--axisCustomColorMyBusinessBackground)",
+  axisCustomColorMyBusinessForeground:
+    "var(--axisCustomColorMyBusinessForeground)",
+  axisCustomColorMyProductsBackground:
+    "var(--axisCustomColorMyProductsBackground)",
+  axisCustomColorMyProductsForeground:
+    "var(--axisCustomColorMyProductsForeground)",
+  axisCustomUtilityThemeName: "var(--axisCustomUtilityThemeName",
+};
+
+export const axisDarkTheme: AxisTheme = {
   ...createDarkTheme(brand),
   colorNeutralForegroundOnBrand: "#000000",
   colorNeutralStroke3: "#2E2E2E",
@@ -44,9 +87,18 @@ export const axisDarkTheme: Theme = {
   colorStatusWarningBorder1: "#884228",
   colorStatusSuccessBackground1: "#113711",
   colorStatusSuccessBorder1: "#116811",
+  axisCustomColorMySystemsBackground: "#004F6E",
+  axisCustomColorMySystemsForeground: "#99D8F1",
+  axisCustomColorMyAxisBackground: "#BC8D00",
+  axisCustomColorMyAxisForeground: "#FFEBAD",
+  axisCustomColorMyBusinessBackground: "#6B0646",
+  axisCustomColorMyBusinessForeground: "#EF9BD1",
+  axisCustomColorMyProductsBackground: "#476320",
+  axisCustomColorMyProductsForeground: "#D1E8B2",
+  axisCustomUtilityThemeName: "axisDarkTheme",
 };
 
-export const axisLightTheme: Theme = {
+export const axisLightTheme: AxisTheme = {
   ...createLightTheme(brand),
   colorNeutralForegroundOnBrand: "#000000",
   colorBrandBackground: "#ffcc33",
@@ -62,6 +114,15 @@ export const axisLightTheme: Theme = {
   colorBrandForegroundLinkPressed: "#026690",
   colorBrandForegroundLinkSelected: "#028fcc",
   colorScrollbarOverlay: "rgba(0,0,0,0.2)",
+  axisCustomColorMyAxisBackground: "#DFA001",
+  axisCustomColorMyAxisForeground: "#FFF5D6",
+  axisCustomColorMySystemsBackground: "#008DC6",
+  axisCustomColorMySystemsForeground: "#CCEBF8",
+  axisCustomColorMyBusinessBackground: "#C10B7E",
+  axisCustomColorMyBusinessForeground: "#F7CEE8",
+  axisCustomColorMyProductsBackground: "#7FB239",
+  axisCustomColorMyProductsForeground: "#E8F4D9",
+  axisCustomUtilityThemeName: "axisLightTheme",
 };
 
 export const blueBrand: BrandVariants = {
@@ -83,6 +144,28 @@ export const blueBrand: BrandVariants = {
   160: "#D4F3FF",
 };
 
-export const axisBlueDarkTheme: Theme = { ...createDarkTheme(blueBrand) };
+export const axisBlueDarkTheme: AxisTheme = {
+  ...createDarkTheme(blueBrand),
+  axisCustomColorMySystemsBackground: "#004F6E",
+  axisCustomColorMySystemsForeground: "#99D8F1",
+  axisCustomColorMyAxisBackground: "#BC8D00",
+  axisCustomColorMyAxisForeground: "#FFEBAD",
+  axisCustomColorMyBusinessBackground: "#6B0646",
+  axisCustomColorMyBusinessForeground: "#EF9BD1",
+  axisCustomColorMyProductsBackground: "#476320",
+  axisCustomColorMyProductsForeground: "#D1E8B2",
+  axisCustomUtilityThemeName: "axisBlueDarkTheme",
+};
 
-export const axisBlueLightTheme: Theme = { ...createLightTheme(blueBrand) };
+export const axisBlueLightTheme: AxisTheme = {
+  ...createLightTheme(blueBrand),
+  axisCustomColorMyAxisBackground: "#DFA001",
+  axisCustomColorMyAxisForeground: "#FFF5D6",
+  axisCustomColorMySystemsBackground: "#008DC6",
+  axisCustomColorMySystemsForeground: "#CCEBF8",
+  axisCustomColorMyBusinessBackground: "#C10B7E",
+  axisCustomColorMyBusinessForeground: "#F7CEE8",
+  axisCustomColorMyProductsBackground: "#7FB239",
+  axisCustomColorMyProductsForeground: "#E8F4D9",
+  axisCustomUtilityThemeName: "axisBlueLightTheme",
+};

--- a/theme/tokens/generated/css/dark.css
+++ b/theme/tokens/generated/css/dark.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Sat, 11 Nov 2023 09:34:28 GMT
+ * Generated on Fri, 17 May 2024 13:10:00 GMT
  */
 
 .dark {
@@ -9,11 +9,13 @@
   --color-status-danger-background3: #c50f1f;
   --color-status-danger-foreground1: #dc626d;
   --color-status-danger-foreground2: #eeacb2;
-  --color-status-danger-foreground3: #dc626d;
+  --color-status-danger-foreground3: #eeacb2;
   --color-status-danger-border-active: #dc626d;
   --color-status-danger-foreground-inverted: #b10e1c;
   --color-status-danger-border1: #901c27;
   --color-status-danger-border2: #dc626d;
+  --color-status-danger-background3-hover: #b10e1c;
+  --color-status-danger-background3-pressed: #960b18;
   --color-status-warning-background1: #492D1D;
   --color-status-warning-background2: #8a3707;
   --color-status-warning-background3: #f7630c;
@@ -151,6 +153,8 @@
   --color-brand-background2: #342818;
   --color-brand-background2-hover: #4C381E;
   --color-brand-background2-pressed: #281E03;
+  --color-brand-background3-static: #B07A0F;
+  --color-brand-background4-static: #4C381E;
   --color-brand-background-inverted: #ffffff;
   --color-brand-background-inverted-hover: #FFFCF1;
   --color-brand-background-inverted-pressed: #FFEEBA;

--- a/theme/tokens/generated/css/global.css
+++ b/theme/tokens/generated/css/global.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Sat, 11 Nov 2023 09:34:28 GMT
+ * Generated on Fri, 17 May 2024 13:10:00 GMT
  */
 
 :root {

--- a/theme/tokens/generated/css/light.css
+++ b/theme/tokens/generated/css/light.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Sat, 11 Nov 2023 09:34:28 GMT
+ * Generated on Fri, 17 May 2024 13:10:00 GMT
  */
 
 .light {
@@ -14,6 +14,8 @@
   --color-status-danger-border-active: #c50f1f;
   --color-status-danger-border1: #eeacb2;
   --color-status-danger-border2: #c50f1f;
+  --color-status-danger-background3-hover: #b10e1c;
+  --color-status-danger-background3-pressed: #960b18;
   --color-status-warning-background1: #fff9f5;
   --color-status-warning-background2: #fdcfb4;
   --color-status-warning-background3: #f7630c;
@@ -151,6 +153,8 @@
   --color-brand-background2: #FFFCF1;
   --color-brand-background2-hover: #FFF6D7;
   --color-brand-background2-pressed: #FFE79B;
+  --color-brand-background3-static: #B07A0F;
+  --color-brand-background4-static: #4C381E;
   --color-brand-background-inverted: #ffffff;
   --color-brand-background-inverted-hover: #FFFCF1;
   --color-brand-background-inverted-pressed: #FFEEBA;

--- a/theme/tokens/generated/json/colors.json
+++ b/theme/tokens/generated/json/colors.json
@@ -120,7 +120,9 @@
   ],
   "#4c381e": [
     "dark.colorBrandBackgroundPressed",
-    "dark.colorBrandBackground2Hover"
+    "dark.colorBrandBackground2Hover",
+    "dark.colorBrandBackground4Static",
+    "light.colorBrandBackground4Static"
   ],
   "#4d4d4d": [
     "light.colorNeutralStrokeAccessiblePressed"
@@ -169,10 +171,12 @@
     "dark.colorBrandForegroundInvertedPressed",
     "dark.colorBrandForegroundOnLightSelected",
     "dark.colorBrandBackgroundSelected",
+    "dark.colorBrandBackground3Static",
     "light.colorBrandForeground2Hover",
     "light.colorBrandForegroundOnLightSelected",
     "light.colorBrandBackgroundPressed",
     "light.colorBrandBackgroundSelected",
+    "light.colorBrandBackground3Static",
     "light.colorCompoundBrandForeground1Pressed",
     "light.colorCompoundBrandStrokePressed"
   ],

--- a/theme/tokens/generated/tokens/dark.json
+++ b/theme/tokens/generated/tokens/dark.json
@@ -22,7 +22,7 @@
         "type": "color"
       },
       "Foreground3": {
-        "value": "#dc626d",
+        "value": "#eeacb2",
         "type": "color"
       },
       "BorderActive": {
@@ -39,6 +39,14 @@
       },
       "Border2": {
         "value": "#dc626d",
+        "type": "color"
+      },
+      "Background3Hover": {
+        "value": "#b10e1c",
+        "type": "color"
+      },
+      "Background3Pressed": {
+        "value": "#960b18",
         "type": "color"
       }
     },
@@ -607,6 +615,14 @@
       },
       "Background2Pressed": {
         "value": "#281E03",
+        "type": "color"
+      },
+      "Background3Static": {
+        "value": "#B07A0F",
+        "type": "color"
+      },
+      "Background4Static": {
+        "value": "#4C381E",
         "type": "color"
       },
       "BackgroundInverted": {

--- a/theme/tokens/generated/tokens/light.json
+++ b/theme/tokens/generated/tokens/light.json
@@ -40,6 +40,14 @@
       "Border2": {
         "value": "#c50f1f",
         "type": "color"
+      },
+      "Background3Hover": {
+        "value": "#b10e1c",
+        "type": "color"
+      },
+      "Background3Pressed": {
+        "value": "#960b18",
+        "type": "color"
       }
     },
     "Warning": {
@@ -607,6 +615,14 @@
       },
       "Background2Pressed": {
         "value": "#FFE79B",
+        "type": "color"
+      },
+      "Background3Static": {
+        "value": "#B07A0F",
+        "type": "color"
+      },
+      "Background4Static": {
+        "value": "#4C381E",
         "type": "color"
       },
       "BackgroundInverted": {

--- a/theme/tokens/generated/ts/axisDarkTheme.ts
+++ b/theme/tokens/generated/ts/axisDarkTheme.ts
@@ -1,11 +1,20 @@
 /**
  * Do not edit directly
- * Generated on Sat, 11 Nov 2023 09:34:30 GMT
+ * Generated on Fri, 17 May 2024 13:10:01 GMT
  */ 
 
 import { Theme } from "@fluentui/react-components";
 
 export const AxisDarkTheme: Theme = {
+  axisCustomColorMyAxisBackground: "#BC8D00",
+  axisCustomColorMyAxisForeground: "#FFEBAD",
+  axisCustomColorMyBusinessBackground: "#6B0646",
+  axisCustomColorMyBusinessForeground: "#EF9BD1",
+  axisCustomColorMyProductsBackground: "#476320",
+  axisCustomColorMyProductsForeground: "#D1E8B2",
+  axisCustomColorMySystemsBackground: "#004F6E",
+  axisCustomColorMySystemsForeground: "#99D8F1",
+  axisCustomUtilityThemeName: "axisDarkTheme",
   borderRadiusCircular: "10000px",
   borderRadiusLarge: "6px",
   borderRadiusMedium: "4px",
@@ -17,6 +26,8 @@ export const AxisDarkTheme: Theme = {
   colorBrandBackground2: "#342818",
   colorBrandBackground2Hover: "#4C381E",
   colorBrandBackground2Pressed: "#281E03",
+  colorBrandBackground3Static: "#B07A0F",
+  colorBrandBackground4Static: "#4C381E",
   colorBrandBackgroundHover: "#EFAB01",
   colorBrandBackgroundInverted: "#ffffff",
   colorBrandBackgroundInvertedHover: "#FFFCF1",
@@ -83,6 +94,11 @@ export const AxisDarkTheme: Theme = {
   colorNeutralBackgroundInverted: "#ffffff",
   colorNeutralBackgroundInvertedDisabled: "rgba(255, 255, 255, 0.1)",
   colorNeutralBackgroundStatic: "#3d3d3d",
+  colorNeutralCardBackground: "#333333",
+  colorNeutralCardBackgroundDisabled: "#141414",
+  colorNeutralCardBackgroundHover: "#3d3d3d",
+  colorNeutralCardBackgroundPressed: "#2e2e2e",
+  colorNeutralCardBackgroundSelected: "#383838",
   colorNeutralForeground1: "#ffffff",
   colorNeutralForeground1Hover: "#ffffff",
   colorNeutralForeground1Pressed: "#ffffff",
@@ -304,12 +320,14 @@ export const AxisDarkTheme: Theme = {
   colorStatusDangerBackground1: "#481D20",
   colorStatusDangerBackground2: "#6e0811",
   colorStatusDangerBackground3: "#c50f1f",
+  colorStatusDangerBackground3Hover: "#b10e1c",
+  colorStatusDangerBackground3Pressed: "#960b18",
   colorStatusDangerBorder1: "#901c27",
   colorStatusDangerBorder2: "#dc626d",
   colorStatusDangerBorderActive: "#dc626d",
   colorStatusDangerForeground1: "#dc626d",
   colorStatusDangerForeground2: "#eeacb2",
-  colorStatusDangerForeground3: "#dc626d",
+  colorStatusDangerForeground3: "#eeacb2",
   colorStatusDangerForegroundInverted: "#b10e1c",
   colorStatusSuccessBackground1: "#113711",
   colorStatusSuccessBackground2: "#094509",

--- a/theme/tokens/generated/ts/axisLightTheme.ts
+++ b/theme/tokens/generated/ts/axisLightTheme.ts
@@ -1,11 +1,20 @@
 /**
  * Do not edit directly
- * Generated on Sat, 11 Nov 2023 09:34:30 GMT
+ * Generated on Fri, 17 May 2024 13:10:01 GMT
  */ 
 
 import { Theme } from "@fluentui/react-components";
 
 export const AxisLightTheme: Theme = {
+  axisCustomColorMyAxisBackground: "#DFA001",
+  axisCustomColorMyAxisForeground: "#FFF5D6",
+  axisCustomColorMyBusinessBackground: "#C10B7E",
+  axisCustomColorMyBusinessForeground: "#F7CEE8",
+  axisCustomColorMyProductsBackground: "#7FB239",
+  axisCustomColorMyProductsForeground: "#E8F4D9",
+  axisCustomColorMySystemsBackground: "#008DC6",
+  axisCustomColorMySystemsForeground: "#CCEBF8",
+  axisCustomUtilityThemeName: "axisLightTheme",
   borderRadiusCircular: "10000px",
   borderRadiusLarge: "6px",
   borderRadiusMedium: "4px",
@@ -17,6 +26,8 @@ export const AxisLightTheme: Theme = {
   colorBrandBackground2: "#FFFCF1",
   colorBrandBackground2Hover: "#FFF6D7",
   colorBrandBackground2Pressed: "#FFE79B",
+  colorBrandBackground3Static: "#B07A0F",
+  colorBrandBackground4Static: "#4C381E",
   colorBrandBackgroundHover: "#FEC10C",
   colorBrandBackgroundInverted: "#ffffff",
   colorBrandBackgroundInvertedHover: "#FFFCF1",
@@ -83,6 +94,11 @@ export const AxisLightTheme: Theme = {
   colorNeutralBackgroundInverted: "#292929",
   colorNeutralBackgroundInvertedDisabled: "rgba(255, 255, 255, 0.1)",
   colorNeutralBackgroundStatic: "#333333",
+  colorNeutralCardBackground: "#fafafa",
+  colorNeutralCardBackgroundDisabled: "#f0f0f0",
+  colorNeutralCardBackgroundHover: "#ffffff",
+  colorNeutralCardBackgroundPressed: "#f5f5f5",
+  colorNeutralCardBackgroundSelected: "#ebebeb",
   colorNeutralForeground1: "#242424",
   colorNeutralForeground1Hover: "#242424",
   colorNeutralForeground1Pressed: "#242424",
@@ -304,6 +320,8 @@ export const AxisLightTheme: Theme = {
   colorStatusDangerBackground1: "#fdf3f4",
   colorStatusDangerBackground2: "#eeacb2",
   colorStatusDangerBackground3: "#c50f1f",
+  colorStatusDangerBackground3Hover: "#b10e1c",
+  colorStatusDangerBackground3Pressed: "#960b18",
   colorStatusDangerBorder1: "#eeacb2",
   colorStatusDangerBorder2: "#c50f1f",
   colorStatusDangerBorderActive: "#c50f1f",

--- a/theme/tokens/generated/ts/base.ts
+++ b/theme/tokens/generated/ts/base.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Sat, 11 Nov 2023 09:34:28 GMT
+ * Generated on Fri, 17 May 2024 13:10:00 GMT
  */
 
 import { LineHeightTokens, FontFamilyTokens, FontSizeTokens, FontWeightTokens, BorderRadiusTokens, StrokeWidthTokens } from "@fluentui/react-components";

--- a/theme/tokens/generated/ts/dark.ts
+++ b/theme/tokens/generated/ts/dark.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Sat, 11 Nov 2023 09:34:28 GMT
+ * Generated on Fri, 17 May 2024 13:10:00 GMT
  */
 
 import { ColorTokens, ShadowTokens, ShadowBrandTokens } from "@fluentui/react-components";
@@ -11,6 +11,8 @@ export const colorTokens: ColorTokens = {
   colorBrandBackground2: "#342818",
   colorBrandBackground2Hover: "#4c381e",
   colorBrandBackground2Pressed: "#281e03",
+  colorBrandBackground3Static: "#b07a0f",
+  colorBrandBackground4Static: "#4c381e",
   colorBrandBackgroundHover: "#efab01",
   colorBrandBackgroundInverted: "#ffffff",
   colorBrandBackgroundInvertedHover: "#fffcf1",
@@ -171,12 +173,14 @@ export const colorStatusTokens: Record<string, string> = {
   colorStatusDangerBackground1: "#481d20",
   colorStatusDangerBackground2: "#6e0811",
   colorStatusDangerBackground3: "#c50f1f",
+  colorStatusDangerBackground3Hover: "#b10e1c",
+  colorStatusDangerBackground3Pressed: "#960b18",
   colorStatusDangerBorder1: "#901c27",
   colorStatusDangerBorder2: "#dc626d",
   colorStatusDangerBorderActive: "#dc626d",
   colorStatusDangerForeground1: "#dc626d",
   colorStatusDangerForeground2: "#eeacb2",
-  colorStatusDangerForeground3: "#dc626d",
+  colorStatusDangerForeground3: "#eeacb2",
   colorStatusDangerForegroundInverted: "#b10e1c",
   colorStatusSuccessBackground1: "#113711",
   colorStatusSuccessBackground2: "#094509",

--- a/theme/tokens/generated/ts/light.ts
+++ b/theme/tokens/generated/ts/light.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Sat, 11 Nov 2023 09:34:28 GMT
+ * Generated on Fri, 17 May 2024 13:10:00 GMT
  */
 
 import { ColorTokens, ShadowTokens, ShadowBrandTokens } from "@fluentui/react-components";
@@ -11,6 +11,8 @@ export const colorTokens: ColorTokens = {
   colorBrandBackground2: "#fffcf1",
   colorBrandBackground2Hover: "#fff6d7",
   colorBrandBackground2Pressed: "#ffe79b",
+  colorBrandBackground3Static: "#b07a0f",
+  colorBrandBackground4Static: "#4c381e",
   colorBrandBackgroundHover: "#fec10c",
   colorBrandBackgroundInverted: "#ffffff",
   colorBrandBackgroundInvertedHover: "#fffcf1",
@@ -171,6 +173,8 @@ export const colorStatusTokens: Record<string, string> = {
   colorStatusDangerBackground1: "#fdf3f4",
   colorStatusDangerBackground2: "#eeacb2",
   colorStatusDangerBackground3: "#c50f1f",
+  colorStatusDangerBackground3Hover: "#b10e1c",
+  colorStatusDangerBackground3Pressed: "#960b18",
   colorStatusDangerBorder1: "#eeacb2",
   colorStatusDangerBorder2: "#c50f1f",
   colorStatusDangerBorderActive: "#c50f1f",

--- a/theme/tokens/generated/xaml/Colors.xaml
+++ b/theme/tokens/generated/xaml/Colors.xaml
@@ -1,6 +1,6 @@
 <!--
   Do not edit directly
-  Generated on Sat, 11 Nov 2023 09:34:28 GMT
+  Generated on Fri, 17 May 2024 13:10:00 GMT
 -->
 <ResourceDictionary
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -11,11 +11,13 @@
   <Color x:Key="Dark.ColorStatusDangerBackground3">#c50f1f</Color>
   <Color x:Key="Dark.ColorStatusDangerForeground1">#dc626d</Color>
   <Color x:Key="Dark.ColorStatusDangerForeground2">#eeacb2</Color>
-  <Color x:Key="Dark.ColorStatusDangerForeground3">#dc626d</Color>
+  <Color x:Key="Dark.ColorStatusDangerForeground3">#eeacb2</Color>
   <Color x:Key="Dark.ColorStatusDangerBorderActive">#dc626d</Color>
   <Color x:Key="Dark.ColorStatusDangerForegroundInverted">#b10e1c</Color>
   <Color x:Key="Dark.ColorStatusDangerBorder1">#901c27</Color>
   <Color x:Key="Dark.ColorStatusDangerBorder2">#dc626d</Color>
+  <Color x:Key="Dark.ColorStatusDangerBackground3Hover">#b10e1c</Color>
+  <Color x:Key="Dark.ColorStatusDangerBackground3Pressed">#960b18</Color>
   <Color x:Key="Dark.ColorStatusWarningBackground1">#492D1D</Color>
   <Color x:Key="Dark.ColorStatusWarningBackground2">#8a3707</Color>
   <Color x:Key="Dark.ColorStatusWarningBackground3">#f7630c</Color>
@@ -153,6 +155,8 @@
   <Color x:Key="Dark.ColorBrandBackground2">#342818</Color>
   <Color x:Key="Dark.ColorBrandBackground2Hover">#4C381E</Color>
   <Color x:Key="Dark.ColorBrandBackground2Pressed">#281E03</Color>
+  <Color x:Key="Dark.ColorBrandBackground3Static">#B07A0F</Color>
+  <Color x:Key="Dark.ColorBrandBackground4Static">#4C381E</Color>
   <Color x:Key="Dark.ColorBrandBackgroundInverted">#ffffff</Color>
   <Color x:Key="Dark.ColorBrandBackgroundInvertedHover">#FFFCF1</Color>
   <Color x:Key="Dark.ColorBrandBackgroundInvertedPressed">#FFEEBA</Color>
@@ -205,6 +209,8 @@
   <Color x:Key="Light.ColorStatusDangerBorderActive">#c50f1f</Color>
   <Color x:Key="Light.ColorStatusDangerBorder1">#eeacb2</Color>
   <Color x:Key="Light.ColorStatusDangerBorder2">#c50f1f</Color>
+  <Color x:Key="Light.ColorStatusDangerBackground3Hover">#b10e1c</Color>
+  <Color x:Key="Light.ColorStatusDangerBackground3Pressed">#960b18</Color>
   <Color x:Key="Light.ColorStatusWarningBackground1">#fff9f5</Color>
   <Color x:Key="Light.ColorStatusWarningBackground2">#fdcfb4</Color>
   <Color x:Key="Light.ColorStatusWarningBackground3">#f7630c</Color>
@@ -342,6 +348,8 @@
   <Color x:Key="Light.ColorBrandBackground2">#FFFCF1</Color>
   <Color x:Key="Light.ColorBrandBackground2Hover">#FFF6D7</Color>
   <Color x:Key="Light.ColorBrandBackground2Pressed">#FFE79B</Color>
+  <Color x:Key="Light.ColorBrandBackground3Static">#B07A0F</Color>
+  <Color x:Key="Light.ColorBrandBackground4Static">#4C381E</Color>
   <Color x:Key="Light.ColorBrandBackgroundInverted">#ffffff</Color>
   <Color x:Key="Light.ColorBrandBackgroundInvertedHover">#FFFCF1</Color>
   <Color x:Key="Light.ColorBrandBackgroundInvertedPressed">#FFEEBA</Color>

--- a/theme/tokens/generated/xaml/ConstantResources.xaml
+++ b/theme/tokens/generated/xaml/ConstantResources.xaml
@@ -1,6 +1,6 @@
 <!--
   Do not edit directly
-  Generated on Sat, 11 Nov 2023 09:34:28 GMT
+  Generated on Fri, 17 May 2024 13:10:00 GMT
 -->
 <ResourceDictionary
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"

--- a/theme/tokens/generated/xaml/Dark.xaml
+++ b/theme/tokens/generated/xaml/Dark.xaml
@@ -1,6 +1,6 @@
 <!--
   Do not edit directly
-  Generated on Sat, 11 Nov 2023 09:34:28 GMT
+  Generated on Fri, 17 May 2024 13:10:00 GMT
 -->
 <ResourceDictionary
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -59,6 +59,16 @@
   <SolidColorBrush
     x:Key="ColorStatusDangerBorder2"
     Color="{StaticResource Dark.ColorStatusDangerBorder2}"
+    p:Freeze="True"
+  />
+  <SolidColorBrush
+    x:Key="ColorStatusDangerBackground3Hover"
+    Color="{StaticResource Dark.ColorStatusDangerBackground3Hover}"
+    p:Freeze="True"
+  />
+  <SolidColorBrush
+    x:Key="ColorStatusDangerBackground3Pressed"
+    Color="{StaticResource Dark.ColorStatusDangerBackground3Pressed}"
     p:Freeze="True"
   />
   <SolidColorBrush
@@ -744,6 +754,16 @@
   <SolidColorBrush
     x:Key="ColorBrandBackground2Pressed"
     Color="{StaticResource Dark.ColorBrandBackground2Pressed}"
+    p:Freeze="True"
+  />
+  <SolidColorBrush
+    x:Key="ColorBrandBackground3Static"
+    Color="{StaticResource Dark.ColorBrandBackground3Static}"
+    p:Freeze="True"
+  />
+  <SolidColorBrush
+    x:Key="ColorBrandBackground4Static"
+    Color="{StaticResource Dark.ColorBrandBackground4Static}"
     p:Freeze="True"
   />
   <SolidColorBrush

--- a/theme/tokens/generated/xaml/Light.xaml
+++ b/theme/tokens/generated/xaml/Light.xaml
@@ -1,6 +1,6 @@
 <!--
   Do not edit directly
-  Generated on Sat, 11 Nov 2023 09:34:28 GMT
+  Generated on Fri, 17 May 2024 13:10:00 GMT
 -->
 <ResourceDictionary
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -59,6 +59,16 @@
   <SolidColorBrush
     x:Key="ColorStatusDangerBorder2"
     Color="{StaticResource Light.ColorStatusDangerBorder2}"
+    p:Freeze="True"
+  />
+  <SolidColorBrush
+    x:Key="ColorStatusDangerBackground3Hover"
+    Color="{StaticResource Light.ColorStatusDangerBackground3Hover}"
+    p:Freeze="True"
+  />
+  <SolidColorBrush
+    x:Key="ColorStatusDangerBackground3Pressed"
+    Color="{StaticResource Light.ColorStatusDangerBackground3Pressed}"
     p:Freeze="True"
   />
   <SolidColorBrush
@@ -744,6 +754,16 @@
   <SolidColorBrush
     x:Key="ColorBrandBackground2Pressed"
     Color="{StaticResource Light.ColorBrandBackground2Pressed}"
+    p:Freeze="True"
+  />
+  <SolidColorBrush
+    x:Key="ColorBrandBackground3Static"
+    Color="{StaticResource Light.ColorBrandBackground3Static}"
+    p:Freeze="True"
+  />
+  <SolidColorBrush
+    x:Key="ColorBrandBackground4Static"
+    Color="{StaticResource Light.ColorBrandBackground4Static}"
     p:Freeze="True"
   />
   <SolidColorBrush


### PR DESCRIPTION
### Describe your changes

* Add custom colors for axis to theme and export them in axisCustomTokens.
* Add a utility token that contains current selected theme.
* Generate new token files from axis theme
* Use custom tokens for my-X application styling in topbar.
This is a breaking change, since topbar requires the tokens to in the axis theme.
(hover, the application will not break if the custom token does not exist, it will just not show correct color)

Update of example page:
![image](https://github.com/AxisCommunications/fluent-components/assets/67627784/b1f9009a-02ee-4579-a184-947b14dd739f)

mySystems
![image](https://github.com/AxisCommunications/fluent-components/assets/67627784/ef865ee1-da45-4e86-959c-fdbaa105ec51)
![image](https://github.com/AxisCommunications/fluent-components/assets/67627784/00b126ba-964b-4b84-b528-5019e847c029)

myAxis
![image](https://github.com/AxisCommunications/fluent-components/assets/67627784/e6c5ec5f-7df2-41cf-bfff-de67f4bf64b5)
![image](https://github.com/AxisCommunications/fluent-components/assets/67627784/bdb1ce23-892a-4c24-b942-ece222215e21)

myBusiness
![image](https://github.com/AxisCommunications/fluent-components/assets/67627784/14ee4076-70d0-4887-acdc-641817c07f74)
![image](https://github.com/AxisCommunications/fluent-components/assets/67627784/d888ad9f-5e9c-4d30-a682-905203ea826f)

MyProducts
![image](https://github.com/AxisCommunications/fluent-components/assets/67627784/f19a4935-7d50-4427-a2c6-693419726b99)
![image](https://github.com/AxisCommunications/fluent-components/assets/67627784/da6b6cce-ae24-400b-b651-26792e4ecf15)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
