### PR TITLE
feat(topbar): add new look for application drawer trigger button when triggerGroupShortName is set

### DIFF
--- a/components/topbar/src/application-drawer.styles.ts
+++ b/components/topbar/src/application-drawer.styles.ts
@@ -1,5 +1,7 @@
 import { makeStyles, shorthands, tokens } from "@fluentui/react-components";
 
+const triggerSpacingWithGroup = tokens.spacingHorizontalS;
+
 export const useApplicationDrawrStyles = makeStyles({
   drawer: {
     ...shorthands.borderRight(0),
@@ -48,6 +50,10 @@ export const useApplicationDrawrStyles = makeStyles({
     ...shorthands.gap(tokens.spacingHorizontalS),
     ...shorthands.padding(tokens.spacingVerticalXS, tokens.spacingHorizontalM),
   },
+  drawerTriggerApplicationWithGroup: {
+    ...shorthands.gap(triggerSpacingWithGroup),
+    ...shorthands.padding(tokens.spacingVerticalXS, triggerSpacingWithGroup),
+  },
   drawerTriggerApplicationIcon: {
     display: "flex",
     color: tokens.colorNeutralForeground2,
@@ -60,6 +66,18 @@ export const useApplicationDrawrStyles = makeStyles({
   },
   drawerTriggerApplicationText: {
     color: tokens.colorNeutralForeground2,
+  },
+  drawerTriggerTextWithGroup: {
+    marginLeft: triggerSpacingWithGroup,
+    color: tokens.colorNeutralForeground2,
+  },
+  triggerDividerWithGroup: {
+    ...shorthands.border("0.5px", "solid", tokens.colorNeutralForeground2),
+    ...shorthands.borderRadius("1px"),
+    height: "12px",
+    boxSizing: "border-box",
+    marginTop: "1px",
+    marginLeft: triggerSpacingWithGroup,
   },
   applicationGroupTitle: {
     display: "flex",

--- a/components/topbar/src/application-drawer.tsx
+++ b/components/topbar/src/application-drawer.tsx
@@ -49,10 +49,25 @@ const DrawerTrigger = (
         onMouseLeave={() => setHover(false)}
       >
         {<ApplicationAreaIcon applicationArea={applicationArea} />}
-        <Divider vertical style={{ padding: "0 0 0 12px" }}></Divider>
+        {currentSelection?.triggerGroupShortName
+          ? (
+            <>
+              <Body1Strong className={styles.drawerTriggerTextWithGroup}>
+                {currentSelection?.triggerGroupShortName}
+              </Body1Strong>
+              <div className={styles.triggerDividerWithGroup}></div>
+            </>
+          )
+          : <Divider vertical style={{ padding: "0 0 0 12px" }}></Divider>}
         {currentSelection
           ? (
-            <div className={styles.drawerTriggerApplication}>
+            <div
+              className={mergeClasses(
+                styles.drawerTriggerApplication,
+                currentSelection?.triggerGroupShortName
+                  && styles.drawerTriggerApplicationWithGroup
+              )}
+            >
               <div
                 className={mergeClasses(
                   styles.drawerTriggerApplicationIcon,

--- a/components/topbar/src/application-drawer.types.ts
+++ b/components/topbar/src/application-drawer.types.ts
@@ -12,11 +12,17 @@ export type SingleApplicationDrawerContent = {
   icon: JSX.Element;
   /** Label to show in opened drawer. */
   label: string;
-  /** Label to show in drawer trigger button when drawer is closed.
+  /**
+   * @deprecated
+   *  Label to show in drawer trigger button when drawer is closed.
    *  If not set, label will be used.
    *  Unused for content with children.
    */
   triggerLabel?: string;
+  /**
+   * Group label to show before triggerLabel
+   */
+  triggerGroupShortName?: string;
 };
 
 export type ApplicationDrawerProps = {

--- a/examples/src/components/top-bar.tsx
+++ b/examples/src/components/top-bar.tsx
@@ -85,6 +85,7 @@ export const Navbar = () => {
           icon: <FishIcon />,
           label: "Fisk",
           id: "fisk",
+          triggerGroupShortName: "FISH",
         },
         {
           icon: <CatIcon />,
@@ -98,6 +99,7 @@ export const Navbar = () => {
       label: "Add",
       triggerLabel: "ADD trigger",
       id: "add",
+      triggerGroupShortName: "ADD",
     },
   ];
 


### PR DESCRIPTION
### Describe your changes

Update Drawer Trigger button to follow new Look from figma:
https://www.figma.com/design/RqNwSw0bq0sjSXT6M5uJGQ/My-Systems---Releases?node-id=2440-5383&m=dev

Will only be used when the property "triggerGroupShortName" is set in ApplicationDrawerContent.
If unset, the look will be unchanged.

**Old look:**
<img width="368" alt="image" src="https://github.com/AxisCommunications/fluent-components/assets/67627784/aba7c230-a85c-4b21-a2ea-ce38cffc2c5b">
<img width="358" alt="image" src="https://github.com/AxisCommunications/fluent-components/assets/67627784/a2086d61-430e-4bf8-aba8-3edd15ad54e3">

**New Look:**
<img width="431" alt="image" src="https://github.com/AxisCommunications/fluent-components/assets/67627784/2ddd2c2d-eb75-4644-8950-741d106a75e9">
<img width="419" alt="image" src="https://github.com/AxisCommunications/fluent-components/assets/67627784/03607d15-f410-470b-bd0d-00b7f6e8f7d7">


### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
