### PR TITLE
feat(slider): add section labels support

### DIFF
--- a/components/slider/src/__snapshots__/range-slider.spec.tsx.snap
+++ b/components/slider/src/__snapshots__/range-slider.spec.tsx.snap
@@ -16,7 +16,7 @@ exports[`range-slider > should render 1`] = `
           >
             <span
               class="axis-Slider__track ___pq61zr0_1xft6bt fnivh3a fc7yr5o f1el4m67 f8yange ftgm304 f1euv43f f1erzq44 f1i1t8d1 f188r07x f1yrba31 f174n9yu"
-              style="left: 20%; width: 20%;"
+              style="width: 20%; left: 20%;"
             />
           </span>
           <div
@@ -71,7 +71,7 @@ exports[`range-slider > should render 1`] = `
         >
           <span
             class="axis-Slider__track ___pq61zr0_1xft6bt fnivh3a fc7yr5o f1el4m67 f8yange ftgm304 f1euv43f f1erzq44 f1i1t8d1 f188r07x f1yrba31 f174n9yu"
-            style="left: 20%; width: 20%;"
+            style="width: 20%; left: 20%;"
           />
         </span>
         <div

--- a/components/slider/src/__snapshots__/slider.spec.tsx.snap
+++ b/components/slider/src/__snapshots__/slider.spec.tsx.snap
@@ -16,7 +16,7 @@ exports[`slider > should render 1`] = `
           >
             <span
               class="axis-Slider__track ___pq61zr0_1xft6bt fnivh3a fc7yr5o f1el4m67 f8yange ftgm304 f1euv43f f1erzq44 f1i1t8d1 f188r07x f1yrba31 f174n9yu"
-              style="left: 0%; width: 20%;"
+              style="width: 20%; left: 0%;"
             />
           </span>
           <div
@@ -53,7 +53,7 @@ exports[`slider > should render 1`] = `
         >
           <span
             class="axis-Slider__track ___pq61zr0_1xft6bt fnivh3a fc7yr5o f1el4m67 f8yange ftgm304 f1euv43f f1erzq44 f1i1t8d1 f188r07x f1yrba31 f174n9yu"
-            style="left: 0%; width: 20%;"
+            style="width: 20%; left: 0%;"
           />
         </span>
         <div

--- a/components/slider/src/mark/label/mark-label.types.ts
+++ b/components/slider/src/mark/label/mark-label.types.ts
@@ -12,6 +12,8 @@ export type MarkLabelSlots = {
 export type MarkLabelProps = ComponentProps<MarkLabelSlots> & {
   value: number;
   label: ReactNode;
+  /** Label is ***active*** only when slider value is **equal** to mark value. */
+  activeEqual?: boolean;
 };
 
 export type MarkLabelState =

--- a/components/slider/src/mark/label/use-mark-label.ts
+++ b/components/slider/src/mark/label/use-mark-label.ts
@@ -14,6 +14,10 @@ export const useMarkLabel_unstable = (
   const minValue = values.length > 1 ? Math.min(...values) : 0;
   const maxValue = Math.max(...values);
 
+  const active = props.activeEqual
+    ? values.some((value) => value === props.value)
+    : props.value >= minValue && props.value <= maxValue;
+
   return {
     root: getNativeElementProps("span", {
       ref,
@@ -26,6 +30,6 @@ export const useMarkLabel_unstable = (
     offset: toPercent(props.value, min, max),
     value: props.value,
     disabled,
-    active: props.value >= minValue && props.value <= maxValue,
+    active,
   };
 };

--- a/components/slider/src/mark/mark.types.ts
+++ b/components/slider/src/mark/mark.types.ts
@@ -8,6 +8,8 @@ import {
 export type MarkDef = {
   value: number;
   label?: ReactNode;
+  /** Mark label is ***active*** only when slider value is **equal** to mark value. */
+  labelEqualActive?: boolean;
 };
 
 export type MarkSlots = {

--- a/components/slider/src/range-slider.spec.tsx
+++ b/components/slider/src/range-slider.spec.tsx
@@ -1,9 +1,10 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+
 import { RangeSlider } from "./range-slider";
-import React from "react";
 import { getControlRoot } from "./test-helpers";
-import { expect, vi } from "vitest";
 
 const expectSliderValues = (elements: HTMLElement[], values: number[]) => {
   expect(elements).toHaveLength(values.length);

--- a/components/slider/src/render-slider.tsx
+++ b/components/slider/src/render-slider.tsx
@@ -1,8 +1,9 @@
+import React from "react";
+
 import { getSlots } from "@fluentui/react-utilities";
 
 import { SliderContextProvider } from "./context/slider-context";
 import { SliderContextValues, SliderSlots, SliderState } from "./slider.types";
-import React from "react";
 
 export const renderSlider_unstable = (
   state: SliderState,
@@ -10,7 +11,7 @@ export const renderSlider_unstable = (
 ) => {
   const { slots, slotProps } = getSlots<SliderSlots>(state);
 
-  const { marks, markLabels, thumbs } = state;
+  const { marks, markLabels, sectionLabels, thumbs } = state;
 
   return (
     <SliderContextProvider value={contextValues.slider}>
@@ -18,19 +19,27 @@ export const renderSlider_unstable = (
         <slots.control {...slotProps.control}>
           <slots.rail {...slotProps.rail}>
             <slots.track {...slotProps.track} />
-            {marks.map((markProps) => (
-              <slots.mark
-                key={markProps.value.toString()}
-                {...slotProps.mark}
-                {...markProps}
-              />
-            ))}
           </slots.rail>
+          {marks.map((markProps) => (
+            <slots.mark
+              key={markProps.value.toString()}
+              {...slotProps.mark}
+              {...markProps}
+            />
+          ))}
           {markLabels.map((markLabelProps) => (
             <slots.markLabel
               key={markLabelProps.value.toString()}
               {...slotProps.markLabel}
               {...markLabelProps}
+            />
+          ))}
+
+          {sectionLabels.map((sectionLabelProps) => (
+            <slots.sectionLabel
+              key={`${sectionLabelProps.edges.from}-${sectionLabelProps.edges.to}`}
+              {...slotProps.sectionLabel}
+              {...sectionLabelProps}
             />
           ))}
           {thumbs.map((thumbProps) => (

--- a/components/slider/src/section/render-section.tsx
+++ b/components/slider/src/section/render-section.tsx
@@ -1,0 +1,10 @@
+import { getSlots } from "@fluentui/react-utilities";
+
+import React from "react";
+import { SectionSlots, SectionState } from "./section.types";
+
+export const renderSection_unstable = (state: SectionState) => {
+  const { slots, slotProps } = getSlots<SectionSlots>(state);
+
+  return <slots.root {...slotProps.root} />;
+};

--- a/components/slider/src/section/section.tsx
+++ b/components/slider/src/section/section.tsx
@@ -1,0 +1,16 @@
+import { ForwardRefComponent } from "@fluentui/react-utilities";
+import React from "react";
+
+import { SectionProps } from "./section.types";
+import { useSection_unstable } from "./use-section";
+import { useSectionStyles_unstable } from "./use-section-styles";
+import { renderSection_unstable } from "./render-section";
+
+export const Section: ForwardRefComponent<SectionProps> = React
+  .forwardRef((props, ref) => {
+    const state = useSection_unstable(props, ref);
+
+    useSectionStyles_unstable(state);
+
+    return renderSection_unstable(state);
+  });

--- a/components/slider/src/section/section.types.ts
+++ b/components/slider/src/section/section.types.ts
@@ -1,0 +1,35 @@
+import {
+  ComponentProps,
+  ComponentState,
+  Slot,
+} from "@fluentui/react-utilities";
+import { ReactNode } from "react";
+
+export type SectionDef = {
+  edges: SectionEdges;
+  label: ReactNode;
+  trackColor?: string;
+};
+
+export type SectionSlots = {
+  root: Slot<"span">;
+};
+
+interface SectionEdges {
+  from?: number;
+  to?: number;
+}
+
+export type SectionProps = ComponentProps<SectionSlots> & {
+  edges: Required<SectionEdges>;
+  label: ReactNode;
+  trackColor?: string;
+};
+
+export type SectionState =
+  & ComponentState<SectionSlots>
+  & {
+    offset: number;
+    disabled: boolean;
+    active: boolean;
+  };

--- a/components/slider/src/section/use-section-styles.ts
+++ b/components/slider/src/section/use-section-styles.ts
@@ -1,0 +1,71 @@
+import {
+  makeStyles,
+  mergeClasses,
+  shorthands,
+  tokens,
+  useFluent,
+} from "@fluentui/react-components";
+
+import {
+  sliderClassNames,
+  sliderDurations,
+  sliderEasings,
+  sliderVars,
+} from "../use-slider-styles";
+import { SectionState } from "./section.types";
+
+const useStyles = makeStyles({
+  root: {
+    ...shorthands.transition(
+      "color",
+      sliderDurations.short,
+      sliderEasings.easeOutFast
+    ),
+    position: "absolute",
+    color: `var(${sliderVars.section.color})`,
+    top: `var(${sliderVars.thumb.size})`,
+    transform: "translateX(-50%)",
+    whiteSpace: "nowrap",
+  },
+  active: {
+    [sliderVars.section.color]: tokens.colorNeutralForeground1,
+  },
+  enabled: {
+    [sliderVars.section.color]: tokens.colorNeutralForeground2,
+  },
+  disabled: {
+    [sliderVars.section.color]: tokens.colorNeutralForegroundDisabled,
+  },
+});
+
+export const useSectionStyles_unstable = (
+  state: SectionState
+): SectionState => {
+  const styles = useStyles();
+
+  const { offset, disabled, active } = state;
+
+  const colorStyles = disabled
+    ? styles.disabled
+    : active
+    ? styles.active
+    : styles.enabled;
+
+  state.root.className = mergeClasses(
+    sliderClassNames.section.label,
+    styles.root,
+    colorStyles,
+    state.root.className
+  );
+
+  const { dir } = useFluent();
+  const offsetDirection = dir === "rtl" ? "right" : "left";
+  state.root.title = "";
+  state.root.style = {
+    cursor: "default",
+    [offsetDirection]: `${offset}%`,
+    ...state.root.style,
+  };
+
+  return state;
+};

--- a/components/slider/src/section/use-section.ts
+++ b/components/slider/src/section/use-section.ts
@@ -1,0 +1,42 @@
+import { getNativeElementProps } from "@fluentui/react-utilities";
+import React from "react";
+
+import { useSliderContext } from "../context/slider-context";
+import { SectionProps, SectionState } from "./section.types";
+import { toPercent } from "../utils";
+
+export const useSection_unstable = (
+  props: SectionProps,
+  ref: React.Ref<HTMLElement>
+): SectionState => {
+  const { min, max, disabled, values } = useSliderContext();
+
+  const from = props.edges.from ?? min;
+  const to = props.edges.to ?? max;
+
+  /**
+   * The sections center position, calculated as the midpoint between left and right.
+   */
+  const center = from + (to - from) / 2;
+
+  const minValue = values.length > 1 ? Math.min(...values) : min;
+  const maxValue = Math.max(...values);
+
+  const active = (minValue > from && minValue < to)
+    || (minValue <= from && maxValue > to)
+    || (maxValue > from && maxValue <= to);
+
+  return {
+    root: getNativeElementProps("span", {
+      ref,
+      children: props.label,
+      ...props,
+    }),
+    components: {
+      root: "span",
+    },
+    offset: toPercent(center, min, max),
+    disabled,
+    active,
+  };
+};

--- a/components/slider/src/slider.types.ts
+++ b/components/slider/src/slider.types.ts
@@ -8,6 +8,7 @@ import { SliderContextValue } from "./context/slider-context";
 import { MarkDef, MarkProps } from "./mark/mark.types";
 import { ThumbProps } from "./thumb/thumb.types";
 import { MarkLabelProps } from "./mark/label/mark-label.types";
+import { SectionDef, SectionProps } from "./section/section.types";
 
 export type SliderContextValues = {
   slider: SliderContextValue;
@@ -21,6 +22,7 @@ export type SliderSlots = {
   thumb: Slot<Partial<ThumbProps>>;
   mark: Slot<Partial<MarkProps>>;
   markLabel: Slot<Partial<MarkLabelProps>>;
+  sectionLabel: Slot<Partial<SectionProps>>;
 };
 
 export type SliderOnChangeData = {
@@ -39,6 +41,7 @@ export type RangeSliderProps =
   & {
     disabled?: boolean;
     marks?: boolean | MarkDef[];
+    sectionLabels?: SectionDef[];
     step?: number | "marks";
     size?: "small" | "medium";
     min: number;
@@ -69,6 +72,7 @@ export type SliderState =
     values: number[];
     marks: MarkProps[];
     markLabels: MarkLabelProps[];
+    sectionLabels: SectionProps[];
     thumbs: ThumbProps[];
     trackOffset: number;
     trackWidth: number;

--- a/components/slider/src/use-slider-styles.ts
+++ b/components/slider/src/use-slider-styles.ts
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+
 import {
   createFocusOutlineStyle,
   makeStyles,
@@ -8,6 +10,7 @@ import {
 } from "@fluentui/react-components";
 
 import { SliderState } from "./slider.types";
+import { toPercent } from "./utils";
 
 export const sliderClassNames = {
   root: "axis-Slider",
@@ -21,6 +24,10 @@ export const sliderClassNames = {
   mark: {
     root: "axis-Slider__mark",
     label: "axis-Slider__mark__label",
+  },
+  section: {
+    root: "axis-Slider__section",
+    label: "axis-Slider__section__label",
   },
 };
 
@@ -44,6 +51,9 @@ export const sliderVars = {
   },
   mark: {
     color: "--axis-Slider__mark--color",
+  },
+  section: {
+    color: "--axis-Slider__section--color",
   },
 };
 
@@ -90,6 +100,9 @@ const useRootStyles = makeStyles({
     },
   }),
   hasMarkLabel: {
+    [sliderVars.root.paddingBottom]: "1rem",
+  },
+  hasSectionLabels: {
     [sliderVars.root.paddingBottom]: "1rem",
   },
 });
@@ -154,13 +167,23 @@ export const useSliderStyles_unstable = (state: SliderState): SliderState => {
   const railStyles = useRailStyles();
   const trackStyles = useTrackStyles();
 
-  const { disabled, trackOffset, trackWidth, active, markLabels, size } = state;
+  const {
+    disabled,
+    trackOffset,
+    trackWidth,
+    active,
+    markLabels,
+    sectionLabels,
+    size,
+    values,
+  } = state;
 
   const { dir } = useFluent();
 
   const rtl = dir === "rtl";
 
   const hasMarkLabel = markLabels.length > 0;
+  const hasSectionLabels = sectionLabels.length > 0;
 
   state.root.className = mergeClasses(
     sliderClassNames.root,
@@ -169,6 +192,7 @@ export const useSliderStyles_unstable = (state: SliderState): SliderState => {
     size === "medium" && rootStyles.medium,
     rootStyles.focusIndicator,
     hasMarkLabel && rootStyles.hasMarkLabel,
+    hasSectionLabels && rootStyles.hasSectionLabels,
     state.root.className
   );
 
@@ -193,10 +217,116 @@ export const useSliderStyles_unstable = (state: SliderState): SliderState => {
     state.track.className
   );
 
+  const hasSectionLabelsAndColors = sectionLabels.length > 0;
+
   const offsetDirection = rtl ? "right" : "left";
+  const offset = hasSectionLabelsAndColors
+    ? undefined
+    : {
+      [offsetDirection]: `${trackOffset}%`,
+    };
+
+  const sectionStyles = useMemo(() => {
+    /** trackColorGradient */
+    let tcg;
+    let thumbColor;
+
+    if (hasSectionLabelsAndColors) {
+      const { min, max } = state;
+      const rangeStart = values[0];
+      const rangeEnd = values.length > 1
+        ? values[values.length - 1]
+        : undefined;
+
+      const trackStart = rangeEnd === undefined ? min : rangeStart;
+      const trackEnd = rangeEnd === undefined ? rangeStart : rangeEnd;
+
+      const defaultColor = tokens.colorCompoundBrandBackground;
+
+      const gradientDirection = !rtl ? "right" : "left";
+
+      tcg = `linear-gradient(to ${gradientDirection}, `;
+      for (const sl of state.sectionLabels) {
+        const color = sl.trackColor ?? defaultColor;
+
+        // start
+        if (sl.edges.from <= trackStart) {
+          if (sl.edges.from < trackStart) {
+            // transparent block before track
+            tcg += `transparent ${toPercent(sl.edges.from, min, max)}%, `;
+            tcg += `transparent ${toPercent(trackStart, min, max)}%, `;
+          }
+
+          if (sl.edges.to > trackStart && sl.edges.to < trackEnd) {
+            tcg += `${color} ${toPercent(trackStart, min, max)}%, `;
+            tcg += `${color} ${toPercent(sl.edges.to, min, max)}%, `;
+          }
+        }
+
+        // middle full
+        if (
+          (sl.edges.from ?? max) >= trackStart
+          && (sl.edges.to ?? max) <= trackEnd
+        ) {
+          tcg += `${color} ${toPercent(sl.edges.from, min, max)}%, `;
+          tcg += `${color} ${toPercent(sl.edges.to, min, max)}%, `;
+        }
+        // middle inside
+        if (
+          (sl.edges.from ?? max) <= trackStart
+          && (sl.edges.to ?? max) >= trackEnd
+        ) {
+          tcg += `${color} ${toPercent(trackStart, min, max)}%, `;
+          tcg += `${color} ${toPercent(trackEnd, min, max)}%, `;
+
+          // transparent block after track
+          tcg += `transparent ${toPercent(trackEnd, min, max)}%, `;
+          tcg += `transparent ${toPercent(sl.edges.to, min, max)}%, `;
+        }
+
+        // end
+        if (sl.edges.from > trackStart && sl.edges.to > trackEnd) {
+          // colored block of track
+          tcg += `${color} ${toPercent(sl.edges.from, min, max)}%, `;
+          tcg += `${color} ${toPercent(trackEnd, min, max)}%, `;
+
+          // transparent block after track
+          tcg += `transparent ${toPercent(trackEnd, min, max)}%, `;
+          tcg += `transparent ${toPercent(sl.edges.to, min, max)}%, `;
+        }
+
+        if (sl.edges.from > trackEnd) {
+          // transparent block after track
+          tcg += `transparent ${toPercent(sl.edges.from, min, max)}%, `;
+          tcg += `transparent ${toPercent(sl.edges.to, min, max)}%, `;
+        }
+      }
+      tcg = tcg.substring(0, tcg.length - 2); // remove trailing ", "
+      tcg += ")";
+
+      thumbColor = tokens.colorCompoundBrandBackground;
+
+      for (const [index, sectionLabel] of state.sectionLabels.entries()) {
+        if (
+          trackEnd === min ? index === 0 : trackEnd > sectionLabel.edges.from
+        ) {
+          thumbColor = sectionLabel.trackColor ?? defaultColor;
+        }
+      }
+
+      return { trackColorGradient: tcg, thumbColor };
+    }
+  }, [values]);
+
+  state.thumb = {
+    style: {
+      backgroundColor: sectionStyles?.thumbColor,
+    },
+  };
   state.track.style = {
-    [offsetDirection]: `${trackOffset}%`,
-    width: `${trackWidth}%`,
+    backgroundImage: sectionStyles?.trackColorGradient,
+    width: hasSectionLabelsAndColors ? "100%" : `${trackWidth}%`,
+    ...offset,
     ...state.track.style,
   };
 

--- a/examples/src/stories/slider/examples/dual-section-example.tsx
+++ b/examples/src/stories/slider/examples/dual-section-example.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+
+import { Slider } from "@axiscommunications/fluent-slider";
+import { makeStyles, tokens } from "@fluentui/react-components";
+
+const useCustomizedSliderStyles = makeStyles({
+  mark: {
+    height: "16px",
+    width: "1px",
+    backgroundColor: "white",
+  },
+  markLabel: {
+    color: tokens.colorPaletteRedForeground1,
+  },
+  track: {
+    backgroundColor: "gray",
+  },
+});
+
+const markValue = 45.5;
+
+export function DualSectionSliderExample() {
+  const classes = useCustomizedSliderStyles();
+  return (
+    <Slider
+      min={0}
+      max={100}
+      title="Click to set zoom level"
+      marks={[{
+        value: markValue,
+        label: "Sweet spot",
+        labelEqualActive: true,
+      }]}
+      sectionLabels={[
+        { edges: { to: markValue }, label: "Lossless zoom" },
+        {
+          edges: { from: markValue },
+          label: "Lossy zoom",
+          trackColor: "white",
+        },
+      ]}
+      markLabel={{
+        style: { fontWeight: "bold" },
+      }}
+      mark={{
+        className: classes.mark,
+      }}
+      track={{
+        className: classes.track,
+      }}
+      defaultValue={33}
+    />
+  );
+}
+
+export const DualSectionSliderExampleAsString = `
+import React from "react";
+
+import { Slider } from "@axiscommunications/fluent-slider";
+import { makeStyles, tokens } from "@fluentui/react-components";
+
+const useCustomizedSliderStyles = makeStyles({
+  mark: {
+    height: "16px",
+    width: "1px",
+    backgroundColor: "white",
+  },
+  markLabel: {
+    color: tokens.colorPaletteRedForeground1,
+  },
+  track: {
+    backgroundColor: "gray",
+  },
+});
+
+const markValue = 45.5;
+
+export function DualSectionSliderExample() {
+  const classes = useCustomizedSliderStyles();
+  return (
+    <Slider
+      min={0}
+      max={100}
+      title="Click to set zoom level"
+      marks={[{ value: markValue, label: "Sweet spot" }]}
+      sectionLabels={[
+        { edges: { right: markValue }, label: "Lossless zoom" },
+        { edges: { left: markValue }, label: "Lossy zoom" },
+      ]}
+      markLabel={{
+        style: { fontWeight: "bold" },
+      }}
+      mark={{
+        className: classes.mark,
+      }}
+      track={{
+        className: classes.track,
+      }}
+      defaultValue={33}
+    />
+  );
+}
+`;

--- a/examples/src/stories/slider/examples/range-slider-with-section-example.tsx
+++ b/examples/src/stories/slider/examples/range-slider-with-section-example.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+
+import { RangeSlider } from "@axiscommunications/fluent-slider";
+import { makeStyles, tokens } from "@fluentui/react-components";
+
+const useCustomizedSliderStyles = makeStyles({
+  mark: {
+    height: "16px",
+    width: "1px",
+    backgroundColor: "white",
+  },
+  markLabel: {
+    color: tokens.colorPaletteRedForeground1,
+  },
+  track: {
+    backgroundColor: "gray",
+  },
+});
+
+export function RangeSliderWithSectionExample() {
+  const classes = useCustomizedSliderStyles();
+  return (
+    <RangeSlider
+      min={-40}
+      max={300}
+      defaultValue={[-10, 37, 69]}
+      title="Click to change the value"
+      marks={[
+        {
+          value: 37,
+          labelEqualActive: true,
+        },
+        {
+          value: 0,
+          label: "Freezing",
+          labelEqualActive: true,
+        },
+        {
+          value: 100,
+          label: "Boiling",
+          labelEqualActive: true,
+        },
+      ]}
+      sectionLabels={[
+        { edges: { to: 0 }, label: "Solid", trackColor: "cyan" },
+        {
+          edges: { from: 0, to: 100 },
+          label: "Liquid",
+          trackColor: "lightblue",
+        },
+        {
+          edges: { from: 100 },
+          label: "Gas",
+          trackColor: "white",
+        },
+      ]}
+      markLabel={{
+        style: { fontWeight: "bold" },
+      }}
+      mark={{
+        className: classes.mark,
+      }}
+      track={{
+        className: classes.track,
+      }}
+    />
+  );
+}
+
+export const RangeSliderWithSectionExampleAsString = `
+import React from "react";
+
+import { RangeSlider } from "@axiscommunications/fluent-slider";
+import { makeStyles, tokens } from "@fluentui/react-components";
+
+const useCustomizedSliderStyles = makeStyles({
+  mark: {
+    height: "16px",
+    width: "1px",
+    backgroundColor: "white",
+  },
+  markLabel: {
+    color: tokens.colorPaletteRedForeground1,
+  },
+  track: {
+    backgroundColor: "gray",
+  },
+});
+
+export function RangeSliderWithSectionExample() {
+  const classes = useCustomizedSliderStyles();
+  return (
+    <RangeSlider
+      min={-40}
+      max={300}
+      defaultValue={[-10, 120]}
+      title="Click to change the value"
+      marks={[
+        {
+          value: 37,
+          labelEqualActive: true,
+        },
+        {
+          value: 0,
+          labelEqualActive: true,
+        },
+        {
+          value: 100,
+          labelEqualActive: true,
+        },
+      ]}
+      sectionLabels={[
+        { edges: { to: 0 }, label: "Solid", trackColor: "cyan" },
+        {
+          edges: { from: 0, to: 100 },
+          label: "Liquid",
+          trackColor: "lightblue",
+        },
+        {
+          edges: { from: 100 },
+          label: "Gas",
+          trackColor: "white",
+        },
+      ]}
+      markLabel={{
+        style: { fontWeight: "bold" },
+      }}
+      mark={{
+        className: classes.mark,
+      }}
+      track={{
+        className: classes.track,
+      }}
+    />
+  );
+}`;

--- a/examples/src/stories/slider/examples/triple-section-example-rtl.tsx
+++ b/examples/src/stories/slider/examples/triple-section-example-rtl.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+
+import { Slider } from "@axiscommunications/fluent-slider";
+import { makeStyles, tokens } from "@fluentui/react-components";
+
+const useCustomizedSliderStyles = makeStyles({
+  mark: {
+    height: "16px",
+    width: "1px",
+    backgroundColor: "white",
+  },
+  markLabel: {
+    color: tokens.colorPaletteRedForeground1,
+  },
+  track: {
+    backgroundColor: "gray",
+  },
+});
+
+export function TripleSectionSliderExample() {
+  const classes = useCustomizedSliderStyles();
+  return (
+    <Slider
+      min={0}
+      max={60}
+      title="Click to change the value"
+      marks={[{
+        value: 20,
+        label: "First mark",
+        labelEqualActive: true,
+      }, {
+        value: 40,
+        label: "Next mark",
+        labelEqualActive: true,
+      }]}
+      sectionLabels={[
+        { edges: { to: 20 }, label: "Section 1", trackColor: "yellow" },
+        {
+          edges: { from: 20, to: 40 },
+          label: "Section 2",
+          trackColor: "orange",
+        },
+        {
+          edges: { from: 40 },
+          label: "Section 3",
+          trackColor: "red ",
+        },
+      ]}
+      markLabel={{
+        style: { fontWeight: "bold" },
+      }}
+      mark={{
+        className: classes.mark,
+      }}
+      track={{
+        className: classes.track,
+      }}
+      defaultValue={50}
+    />
+  );
+}
+
+export const TripleSectionSliderExampleAsString = `
+import React from "react";
+
+import { Slider } from "@axiscommunications/fluent-slider";
+import { makeStyles, tokens } from "@fluentui/react-components";
+
+const useCustomizedSliderStyles = makeStyles({
+  mark: {
+    height: "16px",
+    width: "1px",
+    backgroundColor: "white",
+  },
+  markLabel: {
+    color: tokens.colorPaletteRedForeground1,
+  },
+  track: {
+    backgroundColor: "gray",
+  },
+});
+
+export function TripleSectionSliderExample() {
+  const classes = useCustomizedSliderStyles();
+  return (
+    <Slider
+      min={0}
+      max={60}
+      title="Click to change the value"
+      marks={[{
+        value: 20,
+        label: "First mark",
+        activeOnlyOnMatching: true,
+      }, {
+        value: 40,
+        label: "Other mark",
+        activeOnlyOnMatching: true,
+      }]}
+      sectionLabels={[
+        { edges: { right: 20 }, label: "Section 1", trackColor: "yellow" },
+        {
+          edges: { left: 20, right: 40 },
+          label: "Section 2",
+          trackColor: "orange",
+        },
+        {
+          edges: { left: 40 },
+          label: "Section 3",
+          trackColor: "red ",
+        },
+      ]}
+      markLabel={{
+        style: { fontWeight: "bold" },
+      }}
+      mark={{
+        className: classes.mark,
+      }}
+      track={{
+        className: classes.track,
+      }}
+      defaultValue={50}
+    />
+  );
+}
+`;

--- a/examples/src/stories/slider/examples/triple-section-example.tsx
+++ b/examples/src/stories/slider/examples/triple-section-example.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+
+import { Slider } from "@axiscommunications/fluent-slider";
+import { makeStyles, tokens } from "@fluentui/react-components";
+
+const useCustomizedSliderStyles = makeStyles({
+  mark: {
+    height: "16px",
+    width: "1px",
+    backgroundColor: "white",
+  },
+  markLabel: {
+    color: tokens.colorPaletteRedForeground1,
+  },
+  track: {
+    backgroundColor: "gray",
+  },
+});
+
+export function TripleSectionSliderExample() {
+  const classes = useCustomizedSliderStyles();
+  return (
+    <Slider
+      min={0}
+      max={60}
+      title="Click to change the value"
+      marks={[{
+        value: 20,
+        label: "First mark",
+        labelEqualActive: true,
+      }, {
+        value: 40,
+        label: "Other mark",
+        labelEqualActive: true,
+      }]}
+      sectionLabels={[
+        { edges: { to: 20 }, label: "Section 1", trackColor: "yellow" },
+        {
+          edges: { from: 20, to: 40 },
+          label: "Section 2",
+          trackColor: "orange",
+        },
+        {
+          edges: { from: 40 },
+          label: "Section 3",
+          trackColor: "red ",
+        },
+      ]}
+      markLabel={{
+        style: { fontWeight: "bold" },
+      }}
+      mark={{
+        className: classes.mark,
+      }}
+      track={{
+        className: classes.track,
+      }}
+      defaultValue={50}
+    />
+  );
+}
+
+export const TripleSectionSliderExampleAsString = `
+import React from "react";
+
+import { Slider } from "@axiscommunications/fluent-slider";
+import { makeStyles, tokens } from "@fluentui/react-components";
+
+const useCustomizedSliderStyles = makeStyles({
+  mark: {
+    height: "16px",
+    width: "1px",
+    backgroundColor: "white",
+  },
+  markLabel: {
+    color: tokens.colorPaletteRedForeground1,
+  },
+  track: {
+    backgroundColor: "gray",
+  },
+});
+
+export function TripleSectionSliderExample() {
+  const classes = useCustomizedSliderStyles();
+  return (
+    <Slider
+      min={0}
+      max={60}
+      title="Click to change the value"
+      marks={[{
+        value: 20,
+        label: "First mark",
+        labelEqualActive: true,
+      }, {
+        value: 40,
+        label: "Other mark",
+        labelEqualActive: true,
+      }]}
+      sectionLabels={[
+        { edges: { to: 20 }, label: "Section 1", trackColor: "yellow" },
+        {
+          edges: { from: 20, to: 40 },
+          label: "Section 2",
+          trackColor: "orange",
+        },
+        {
+          edges: { from: 40 },
+          label: "Section 3",
+          trackColor: "red ",
+        },
+      ]}
+      markLabel={{
+        style: { fontWeight: "bold" },
+      }}
+      mark={{
+        className: classes.mark,
+      }}
+      track={{
+        className: classes.track,
+      }}
+      defaultValue={50}
+    />
+  );
+}
+`;

--- a/examples/src/stories/slider/examples/triple-section-no-zero-start-example.tsx
+++ b/examples/src/stories/slider/examples/triple-section-no-zero-start-example.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+
+import { Slider } from "@axiscommunications/fluent-slider";
+import { makeStyles, tokens } from "@fluentui/react-components";
+
+const useCustomizedSliderStyles = makeStyles({
+  mark: {
+    height: "16px",
+    width: "1px",
+    backgroundColor: "white",
+  },
+  markLabel: {
+    color: tokens.colorPaletteRedForeground1,
+  },
+  track: {
+    backgroundColor: "gray",
+  },
+});
+
+export function TripleSectionSliderNoZeroStartExample() {
+  const classes = useCustomizedSliderStyles();
+  return (
+    <Slider
+      min={-40}
+      max={300}
+      defaultValue={0}
+      title="Click to change the value"
+      marks={[
+        {
+          value: 37,
+          // label: "Body temperature",
+          labelEqualActive: true,
+        },
+        {
+          value: 0,
+          labelEqualActive: true,
+        },
+        {
+          value: 100,
+          labelEqualActive: true,
+        },
+      ]}
+      sectionLabels={[
+        { edges: { to: 0 }, label: "Solid", trackColor: "cyan" },
+        {
+          edges: { from: 0, to: 100 },
+          label: "Liquid",
+          trackColor: "lightblue",
+        },
+        {
+          edges: { from: 100 },
+          label: "Gas",
+          trackColor: "white",
+        },
+      ]}
+      markLabel={{
+        style: { fontWeight: "bold" },
+      }}
+      mark={{
+        className: classes.mark,
+      }}
+      track={{
+        className: classes.track,
+      }}
+    />
+  );
+}
+
+export const TripleSectionSliderNoZeroStartExampleAsString = `
+import React from "react";
+
+import { Slider } from "@axiscommunications/fluent-slider";
+import { makeStyles, tokens } from "@fluentui/react-components";
+
+const useCustomizedSliderStyles = makeStyles({
+  mark: {
+    height: "16px",
+    width: "1px",
+    backgroundColor: "white",
+  },
+  markLabel: {
+    color: tokens.colorPaletteRedForeground1,
+  },
+  track: {
+    backgroundColor: "gray",
+  },
+});
+
+export function TripleSectionSliderNoZeroStartExample() {
+  const classes = useCustomizedSliderStyles();
+  return (
+    <Slider
+      min={-40}
+      max={300}
+      defaultValue={0}
+      title="Click to change the value"
+      marks={[
+        {
+          value: 37,
+          // label: "Body temperature",
+          labelEqualActive: true,
+        },
+        {
+          value: 0,
+          labelEqualActive: true,
+        },
+        {
+          value: 100,
+          labelEqualActive: true,
+        },
+      ]}
+      sectionLabels={[
+        { edges: { to: 0 }, label: "Solid", trackColor: "cyan" },
+        {
+          edges: { from: 0, to: 100 },
+          label: "Liquid",
+          trackColor: "lightblue",
+        },
+        {
+          edges: { from: 100 },
+          label: "Gas",
+          trackColor: "white",
+        },
+      ]}
+      markLabel={{
+        style: { fontWeight: "bold" },
+      }}
+      mark={{
+        className: classes.mark,
+      }}
+      track={{
+        className: classes.track,
+      }}
+    />
+  );
+}`;

--- a/examples/src/stories/slider/examples/with-range-example.tsx
+++ b/examples/src/stories/slider/examples/with-range-example.tsx
@@ -7,7 +7,7 @@ export function RangeSliderExample() {
       title="Range Slider"
       min={0}
       max={100}
-      defaultValue={[25, 75]}
+      defaultValue={[25, 50, 75]}
       marks={[
         { value: 20, label: "20" },
         { value: 40, label: "40" },

--- a/examples/src/stories/slider/slider-page.tsx
+++ b/examples/src/stories/slider/slider-page.tsx
@@ -56,6 +56,23 @@ import {
   WithStepsAndMarksRangeSliderExampleAsString,
 } from "./examples/range-slider-with-streps-and-marks-example";
 
+import {
+  DualSectionSliderExample,
+  DualSectionSliderExampleAsString,
+} from "./examples/dual-section-example";
+import {
+  TripleSectionSliderExample,
+  TripleSectionSliderExampleAsString,
+} from "./examples/triple-section-example";
+import {
+  TripleSectionSliderNoZeroStartExample,
+  TripleSectionSliderNoZeroStartExampleAsString,
+} from "./examples/triple-section-no-zero-start-example";
+import {
+  RangeSliderWithSectionExample,
+  RangeSliderWithSectionExampleAsString,
+} from "./examples/range-slider-with-section-example";
+
 const useStyles = makeStyles({
   example: {
     maxWidth: "auto",
@@ -135,6 +152,31 @@ const examples: pageData[] = [
     example: <WithStepsRangeSliderExample />,
     codeString: WithStepsRangeSliderExampleAsString,
   },
+
+  {
+    title: "Dual section",
+    anchor: "DualSectionSliderExample",
+    example: <DualSectionSliderExample />,
+    codeString: DualSectionSliderExampleAsString,
+  },
+  {
+    title: "Triple section",
+    anchor: "TripleSectionSliderExample",
+    example: <TripleSectionSliderExample />,
+    codeString: TripleSectionSliderExampleAsString,
+  },
+  {
+    title: "Triple section with negative section",
+    anchor: "TripleSectionSliderNoZeroStartExample",
+    example: <TripleSectionSliderNoZeroStartExample />,
+    codeString: TripleSectionSliderNoZeroStartExampleAsString,
+  },
+  {
+    title: "Range slider with section",
+    anchor: "RangeSliderWithSliderExample",
+    example: <RangeSliderWithSectionExample />,
+    codeString: RangeSliderWithSectionExampleAsString,
+  },
 ];
 
 export const SliderPage = () => {
@@ -142,14 +184,10 @@ export const SliderPage = () => {
   const styles = useStyles();
 
   const { renderSections, renderNavigation } = useExampleWithNavigation(
-    examples.map(d => {
+    examples.map((d) => {
       return {
         ...d,
-        example: (
-          <div className={styles.example}>
-            {d.example}
-          </div>
-        ),
+        example: <div className={styles.example}>{d.example}</div>,
       };
     })
   );

--- a/examples/src/stories/slider/slider-page.tsx
+++ b/examples/src/stories/slider/slider-page.tsx
@@ -58,7 +58,7 @@ import {
 
 const useStyles = makeStyles({
   example: {
-    maxWidth: "400px",
+    maxWidth: "auto",
   },
 });
 

--- a/tools/generated/changelog/changeset.js
+++ b/tools/generated/changelog/changeset.js
@@ -63,7 +63,7 @@ function parseConventionalCommitMessage(msg) {
         if (match === null) {
             throw new Error("no matches found");
         }
-        const [_, group, scope, breaking, title] = match;
+        const [, group, scope, breaking, title] = match;
         return {
             group,
             scope,

--- a/tools/src/changelog/changeset.ts
+++ b/tools/src/changelog/changeset.ts
@@ -115,7 +115,7 @@ function parseConventionalCommitMessage(msg: string): ConventionalCommit {
     if (match === null) {
       throw new Error("no matches found");
     }
-    const [_, group, scope, breaking, title] = match;
+    const [, group, scope, breaking, title] = match;
     return {
       group,
       scope,


### PR DESCRIPTION
### Describe your changes

We need a slider with sections that have labels and customable track colors.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation

![image](https://github.com/user-attachments/assets/13790b05-20f9-4cc5-bab7-4f7ae27fc8f8)
