### PR TITLE
fix(topbar): content base height in organization menu

### DIFF
--- a/components/topbar/src/organization.styles.ts
+++ b/components/topbar/src/organization.styles.ts
@@ -7,7 +7,7 @@ export const useStyles = makeStyles({
   organizationSelection: {
     overflowY: "auto",
     overflowX: "hidden",
-    height: "30vh",
+    maxHeight: "30vh",
     width: "290px",
   },
   singleLine: {


### PR DESCRIPTION
### Describe your changes

Organisation menu now has the height fitting the content

### Issue ticket number and link

- Fixes [LKPH-1993](https://jira.se.axis.com/browse/LKPH-1993)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
