### PR TITLE
fix(slider): disable thumb input when slider disabled

### DIFF
--- a/components/slider/package.json
+++ b/components/slider/package.json
@@ -20,8 +20,8 @@
     "check:unused-deps": "depcheck . --config=depcheck.yml",
     "lint": "tsc --noEmit && eslint . --cache",
     "test": "vitest run",
-    "test:update-snapshots": "vitest -u",
     "test:coverage": "vitest run --coverage",
+    "test:update-snapshots": "vitest -u",
     "test:watch": "vitest watch"
   },
   "devDependencies": {

--- a/components/slider/src/range-slider.spec.tsx
+++ b/components/slider/src/range-slider.spec.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
 
 import { RangeSlider } from "./range-slider";
 import { getControlRoot } from "./test-helpers";
@@ -34,6 +35,14 @@ describe("range-slider", () => {
       <RangeSlider min={0} max={100} defaultValue={[10, 20]} />
     );
     expectSliderValues(getAllByRole("slider"), [10, 20]);
+  });
+
+  it("should be disabled", () => {
+    const { getByTestId } = render(
+      <RangeSlider min={0} max={100} data-testid="slider-root" disabled />
+    );
+
+    expect(getByTestId("slider-root").querySelector("input")).toBeDisabled();
   });
 
   describe("mouse interaction", () => {

--- a/components/slider/src/slider.spec.tsx
+++ b/components/slider/src/slider.spec.tsx
@@ -1,11 +1,12 @@
 import { fireEvent, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
 import React from "react";
 import { sliderClassNames } from "./use-slider-styles";
 import { FluentProvider } from "@fluentui/react-components";
 import { Slider } from "./slider";
 import { getControlRoot } from "./test-helpers";
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 const expectSliderValue = (element: HTMLElement, value: number) => {
   expect(element.getAttribute("value")).toEqual(value.toString());
@@ -128,6 +129,14 @@ describe("slider", () => {
       fireEvent.mouseDown(controlRoot, { button: 0, clientX: 0 });
 
       expect(document.activeElement).toEqual(slider);
+    });
+
+    it("should be disabled", () => {
+      const { getByTestId } = render(
+        <Slider min={0} max={100} data-testid="slider-root" disabled />
+      );
+
+      expect(getByTestId("slider-root").querySelector("input")).toBeDisabled();
     });
 
     it("should ignore non-left click", () => {

--- a/components/slider/src/use-slider-styles.ts
+++ b/components/slider/src/use-slider-styles.ts
@@ -319,7 +319,9 @@ export const useSliderStyles_unstable = (state: SliderState): SliderState => {
   }, [values]);
 
   state.thumb = {
+    ...state.thumb,
     style: {
+      ...state.thumb?.style,
       backgroundColor: sectionStyles?.thumbColor,
     },
   };


### PR DESCRIPTION
### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes regression in slider introduced with https://github.com/AxisCommunications/fluent-components/pull/288 causing the backing input field (in thumb) not being disabled when the slider is passed the disabled prop.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
