### PR TITLE
fix(topbar): only close drawer on application change with new callback

### DIFF
--- a/components/topbar/src/application-drawer-v1.tsx
+++ b/components/topbar/src/application-drawer-v1.tsx
@@ -207,6 +207,7 @@ export const ApplicationDrawerV1 = ({
   applicationId,
   content,
   onChange,
+  onChangeAndClose,
   applicationArea,
 }: ApplicationDrawerProps & { applicationArea: ApplicationArea }) => {
   const { t } = useTranslation();
@@ -216,9 +217,15 @@ export const ApplicationDrawerV1 = ({
 
   const onClickItem = (id: string) => {
     if (id !== currentSelection?.id) {
-      onChange(id);
+      if (onChangeAndClose) {
+        onChangeAndClose(id);
+        setIsOpen(false);
+      } else {
+        onChange?.(id);
+      }
+    } else {
+      setIsOpen(false);
     }
-    setIsOpen(false);
   };
 
   return (

--- a/components/topbar/src/application-drawer-v2.tsx
+++ b/components/topbar/src/application-drawer-v2.tsx
@@ -171,6 +171,7 @@ export const ApplicationDrawerV2 = ({
   applicationId,
   content,
   onChange,
+  onChangeAndClose,
 }: ApplicationDrawerProps & { applicationArea: ApplicationArea }) => {
   const [isOpen, setIsOpen] = useState(false);
   const styles = useApplicationDrawerV2Styles();
@@ -178,9 +179,15 @@ export const ApplicationDrawerV2 = ({
 
   const onClickItem = (id: string) => {
     if (id !== currentSelection?.id) {
-      onChange(id);
+      if (onChangeAndClose) {
+        onChangeAndClose(id);
+        setIsOpen(false);
+      } else {
+        onChange?.(id);
+      }
+    } else {
+      setIsOpen(false);
     }
-    setIsOpen(false);
   };
 
   return (

--- a/components/topbar/src/application-drawer.types.ts
+++ b/components/topbar/src/application-drawer.types.ts
@@ -40,5 +40,10 @@ export type ApplicationDrawerProps = {
   title: JSX.Element;
   content?: ApplicationDrawerContent[];
   applicationId: string;
-  onChange: (id: string) => void;
+  onChange?: (id: string) => void;
+  /**
+   * Supply this function if you want the drawer to close the drawer after the action.
+   * Supplying this function will cause onChange callback function to be ignored.
+   */
+  onChangeAndClose?: (id: string) => void;
 };


### PR DESCRIPTION
### Describe your changes

Revisited the app drawer closing on change callback. Since this animated strange when navigating away from page this is now made optional by having the possibility to supply a different callback function.

### Issue ticket number and link

- Fixes [LKPH-2117](https://jira.se.axis.com/browse/LKPH-2117)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
