### PR TITLE
fix: correct config files in examples

### DIFF
--- a/components/empty-view/package.json
+++ b/components/empty-view/package.json
@@ -27,7 +27,6 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "eslint": "^8.57.1",
-    "jsdom": "^22.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^4.5.5"

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es5", "es6", "dom", "dom.iterable", "ES2015", "es2017"],
     "types": ["node"],
     "paths": {
+      "@axiscommunications/fluent-empty-view": ["components/empty-view/src"],
       "@axiscommunications/fluent-hooks": ["hooks/src"],
       "@axiscommunications/fluent-password-input": [
         "components/password-input/src"

--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
   base: "/fluent-components/",
   resolve: {
     alias: {
+      "@axiscommunications/fluent-empty-view": path.resolve(
+        "../components/empty-view/src/index.ts"
+      ),
       "@axiscommunications/fluent-icons": path.resolve("../icons/src/index.ts"),
       "@axiscommunications/fluent-stepper": path.resolve(
         "../components/stepper/src/index.ts"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,9 +73,6 @@ importers:
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
-      jsdom:
-        specifier: ^22.1.0
-        version: 22.1.0
       react:
         specifier: ^18.2.0
         version: 18.3.1


### PR DESCRIPTION
Adds empty-view path to vite config and tsconfig in examples. Removes unused deps from empty-view.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
