### PR TITLE
chore: more strict type illusterationkind and prop drill classname an…

### DIFF
--- a/components/empty-view/src/constants.ts
+++ b/components/empty-view/src/constants.ts
@@ -14,6 +14,8 @@ import {
   EmptySpaceLight,
   FileMissingDark,
   FileMissingLight,
+  MediaDark,
+  MediaLight,
   NoAccessDark,
   NoAccessLight,
   NoConnectionDark,
@@ -34,8 +36,6 @@ import {
   TeamLight,
   UnderConstructionDark,
   UnderConstructionLight,
-  MediaLight,
-  MediaDark,
 } from "@axiscommunications/fluent-illustrations";
 import { IllustrationKind } from "./types";
 

--- a/components/empty-view/src/constants.ts
+++ b/components/empty-view/src/constants.ts
@@ -53,6 +53,7 @@ export const Illustration: Record<
   "empty-space": bundleIllustrationSmart(EmptySpaceDark, EmptySpaceLight),
   "file-missing": bundleIllustrationSmart(FileMissingDark, FileMissingLight),
   general: bundleIllustrationSmart(EmptyGeneralDark, EmptyGeneralLight),
+  media: bundleIllustrationSmart(MediaDark, MediaLight),
   "no-access": bundleIllustrationSmart(NoAccessDark, NoAccessLight),
   "no-connection": bundleIllustrationSmart(NoConnectionDark, NoConnectionLight),
   "no-content": bundleIllustrationSmart(NoContentDark, NoContentLight),
@@ -61,7 +62,6 @@ export const Illustration: Record<
   "not-found": bundleIllustrationSmart(NotFoundDark, NotFoundLight),
   settings: bundleIllustrationSmart(SettingsDark, SettingsLight),
   success: bundleIllustrationSmart(SuccessDark, SuccessLight),
-  media: bundleIllustrationSmart(MediaDark, MediaLight),
   team: bundleIllustrationSmart(TeamDark, TeamLight),
   "under-construction": bundleIllustrationSmart(
     UnderConstructionDark,

--- a/components/empty-view/src/constants.ts
+++ b/components/empty-view/src/constants.ts
@@ -37,8 +37,12 @@ import {
   MediaLight,
   MediaDark,
 } from "@axiscommunications/fluent-illustrations";
+import { IllustrationKind } from "./types";
 
-export const Illustration = {
+export const Illustration: Record<
+  IllustrationKind,
+  ReturnType<typeof bundleIllustrationSmart>
+> = {
   "add-user-profile": bundleIllustrationSmart(
     AddUserProfileDark,
     AddUserProfileLight

--- a/components/empty-view/src/constants.ts
+++ b/components/empty-view/src/constants.ts
@@ -34,12 +34,11 @@ import {
   TeamLight,
   UnderConstructionDark,
   UnderConstructionLight,
+  MediaLight,
+  MediaDark,
 } from "@axiscommunications/fluent-illustrations";
 
-export const Illustration: Record<
-  string,
-  ReturnType<typeof bundleIllustrationSmart>
-> = {
+export const Illustration = {
   "add-user-profile": bundleIllustrationSmart(
     AddUserProfileDark,
     AddUserProfileLight
@@ -58,6 +57,7 @@ export const Illustration: Record<
   "not-found": bundleIllustrationSmart(NotFoundDark, NotFoundLight),
   settings: bundleIllustrationSmart(SettingsDark, SettingsLight),
   success: bundleIllustrationSmart(SuccessDark, SuccessLight),
+  media: bundleIllustrationSmart(MediaDark, MediaLight),
   team: bundleIllustrationSmart(TeamDark, TeamLight),
   "under-construction": bundleIllustrationSmart(
     UnderConstructionDark,

--- a/components/empty-view/src/styles.ts
+++ b/components/empty-view/src/styles.ts
@@ -55,11 +55,9 @@ export const useStyles = makeStyles({
   },
 });
 
-export function useScreenStylesStyles({
-  className,
-}: HtmlDivAttributesRestProps) {
+export function useContainerStyle({ className }: HtmlDivAttributesRestProps) {
   const styles = useStyles();
   const containerStyle = mergeClasses(styles.container, className);
 
-  return { styles, containerStyle };
+  return containerStyle;
 }

--- a/components/empty-view/src/styles.ts
+++ b/components/empty-view/src/styles.ts
@@ -1,4 +1,10 @@
-import { makeStyles, shorthands, tokens } from "@fluentui/react-components";
+import {
+  makeStyles,
+  mergeClasses,
+  shorthands,
+  tokens,
+} from "@fluentui/react-components";
+import { HtmlDivAttributesRestProps } from "./types";
 
 export const useStyles = makeStyles({
   container: {
@@ -48,3 +54,12 @@ export const useStyles = makeStyles({
     verticalAlign: "middle",
   },
 });
+
+export function useScreenStylesStyles({
+  className,
+}: HtmlDivAttributesRestProps) {
+  const styles = useStyles();
+  const containerStyle = mergeClasses(styles.container, className);
+
+  return { styles, containerStyle };
+}

--- a/components/empty-view/src/types.ts
+++ b/components/empty-view/src/types.ts
@@ -1,4 +1,4 @@
-import { PropsWithChildren, ReactNode } from "react";
+import { HTMLAttributes, PropsWithChildren, ReactNode } from "react";
 
 import { Illustration } from "./constants";
 
@@ -10,8 +10,15 @@ export interface ContentProps {
   readonly title: string;
 }
 
-export type EmptyViewProps = PropsWithChildren<{
-  readonly after?: ReactNode;
-  readonly illustration: IllustrationKind;
-  readonly title: string;
-}>;
+export type EmptyViewProps = PropsWithChildren<
+  {
+    readonly after?: ReactNode;
+    readonly illustration: IllustrationKind;
+    readonly title: string;
+  } & HtmlDivAttributesRestProps
+>;
+
+export type HtmlDivAttributesRestProps = Pick<
+  HTMLAttributes<HTMLDivElement>,
+  "className" | "style"
+>;

--- a/components/empty-view/src/types.ts
+++ b/components/empty-view/src/types.ts
@@ -8,6 +8,7 @@ export type IllustrationKind =
   | "empty-space"
   | "file-missing"
   | "general"
+  | "media"
   | "no-access"
   | "no-connection"
   | "no-content"
@@ -16,7 +17,6 @@ export type IllustrationKind =
   | "not-found"
   | "settings"
   | "success"
-  | "media"
   | "team"
   | "under-construction";
 

--- a/components/empty-view/src/types.ts
+++ b/components/empty-view/src/types.ts
@@ -1,8 +1,24 @@
 import { HTMLAttributes, PropsWithChildren, ReactNode } from "react";
 
-import { Illustration } from "./constants";
-
-export type IllustrationKind = keyof typeof Illustration;
+export type IllustrationKind =
+  | "add-user-profile"
+  | "data"
+  | "devices"
+  | "empty-folder"
+  | "empty-space"
+  | "file-missing"
+  | "general"
+  | "no-access"
+  | "no-connection"
+  | "no-content"
+  | "no-match"
+  | "no-sites"
+  | "not-found"
+  | "settings"
+  | "success"
+  | "media"
+  | "team"
+  | "under-construction";
 
 export interface ContentProps {
   readonly body: ReactNode;

--- a/components/empty-view/src/view.tsx
+++ b/components/empty-view/src/view.tsx
@@ -24,7 +24,7 @@ function ContainerSpacious(
     HtmlDivAttributesRestProps
   >
 ) {
-  const styles = useStyles()
+  const styles = useStyles();
   const containerStyle = useContainerStyle({ className });
 
   return (
@@ -42,7 +42,7 @@ function ContainerCompact(
     HtmlDivAttributesRestProps
   >
 ) {
-  const styles = useStyles()
+  const styles = useStyles();
   const containerStyle = useContainerStyle({ className });
 
   return (
@@ -59,7 +59,7 @@ function ContainerTop(
     HtmlDivAttributesRestProps
   >
 ) {
-  const styles = useStyles()
+  const styles = useStyles();
   const containerStyle = useContainerStyle({ className });
 
   return (

--- a/components/empty-view/src/view.tsx
+++ b/components/empty-view/src/view.tsx
@@ -12,10 +12,18 @@ import {
 import { useMediaQuery } from "@axiscommunications/fluent-hooks";
 
 import { useScreenStylesStyles, useStyles } from "./styles";
-import { HtmlDivAttributesRestProps, ContentProps, EmptyViewProps } from "./types";
+import {
+  ContentProps,
+  EmptyViewProps,
+  HtmlDivAttributesRestProps,
+} from "./types";
 import { Illustration } from "./constants";
 
-function ContainerSpacious({ children, className, ...rest }: PropsWithChildren<HtmlDivAttributesRestProps>) {
+function ContainerSpacious(
+  { children, className, ...rest }: PropsWithChildren<
+    HtmlDivAttributesRestProps
+  >
+) {
   const { styles, containerStyle } = useScreenStylesStyles({ className });
 
   return (
@@ -28,7 +36,11 @@ function ContainerSpacious({ children, className, ...rest }: PropsWithChildren<H
   );
 }
 
-function ContainerCompact({ children, className, ...rest }: PropsWithChildren<HtmlDivAttributesRestProps>) {
+function ContainerCompact(
+  { children, className, ...rest }: PropsWithChildren<
+    HtmlDivAttributesRestProps
+  >
+) {
   const { styles, containerStyle } = useScreenStylesStyles({ className });
 
   return (
@@ -40,7 +52,11 @@ function ContainerCompact({ children, className, ...rest }: PropsWithChildren<Ht
   );
 }
 
-function ContainerTop({ children, className, ...rest }: PropsWithChildren<HtmlDivAttributesRestProps>) {
+function ContainerTop(
+  { children, className, ...rest }: PropsWithChildren<
+    HtmlDivAttributesRestProps
+  >
+) {
   const { styles, containerStyle } = useScreenStylesStyles({ className });
 
   return (
@@ -131,7 +147,7 @@ export function PanelEmptyView(
 ) {
   const screenStyles = useStyles();
   return (
-    <ContainerTop  {...rest}>
+    <ContainerTop {...rest}>
       <ContentMedium
         illustration={illustration}
         title={title}
@@ -146,7 +162,7 @@ export function SubmenuEmptyView(
   { illustration, title, children, ...rest }: Omit<EmptyViewProps, "after">
 ) {
   return (
-    <ContainerTop  {...rest}>
+    <ContainerTop {...rest}>
       <ContentSmall illustration={illustration} title={title} body={children} />
     </ContainerTop>
   );
@@ -170,7 +186,7 @@ export function DialogEmptyView(
 ) {
   const screenStyles = useStyles();
   return (
-    <ContainerCompact  {...rest}>
+    <ContainerCompact {...rest}>
       <ContentExtraSmall title={title} body={children} />
       <div className={screenStyles.after}>{after}</div>
     </ContainerCompact>

--- a/components/empty-view/src/view.tsx
+++ b/components/empty-view/src/view.tsx
@@ -11,38 +11,41 @@ import {
 
 import { useMediaQuery } from "@axiscommunications/fluent-hooks";
 
-import { useStyles } from "./styles";
-import { ContentProps, EmptyViewProps } from "./types";
+import { useScreenStylesStyles, useStyles } from "./styles";
+import { HtmlDivAttributesRestProps, ContentProps, EmptyViewProps } from "./types";
 import { Illustration } from "./constants";
 
-function ContainerSpacious({ children }: PropsWithChildren) {
-  const screenStyles = useStyles();
+function ContainerSpacious({ children, className, ...rest }: PropsWithChildren<HtmlDivAttributesRestProps>) {
+  const { styles, containerStyle } = useScreenStylesStyles({ className });
+
   return (
-    <div className={screenStyles.container}>
-      <div className={screenStyles.spacer} />
+    <div className={containerStyle} {...rest}>
+      <div className={styles.spacer} />
       {children}
-      <div className={screenStyles.spacer} />
-      <div className={screenStyles.spacer} />
+      <div className={styles.spacer} />
+      <div className={styles.spacer} />
     </div>
   );
 }
 
-function ContainerCompact({ children }: PropsWithChildren) {
-  const screenStyles = useStyles();
+function ContainerCompact({ children, className, ...rest }: PropsWithChildren<HtmlDivAttributesRestProps>) {
+  const { styles, containerStyle } = useScreenStylesStyles({ className });
+
   return (
-    <div className={screenStyles.container}>
-      <div className={screenStyles.spacer} />
+    <div className={containerStyle} {...rest}>
+      <div className={styles.spacer} />
       {children}
-      <div className={screenStyles.spacer} />
+      <div className={styles.spacer} />
     </div>
   );
 }
 
-function ContainerTop({ children }: PropsWithChildren) {
-  const screenStyles = useStyles();
+function ContainerTop({ children, className, ...rest }: PropsWithChildren<HtmlDivAttributesRestProps>) {
+  const { styles, containerStyle } = useScreenStylesStyles({ className });
+
   return (
-    <div className={screenStyles.container}>
-      <div className={screenStyles.fixedSpacer} />
+    <div className={containerStyle} {...rest}>
+      <div className={styles.fixedSpacer} />
       {children}
     </div>
   );
@@ -97,12 +100,12 @@ function ContentExtraSmall(
 }
 
 export function MainEmptyView(
-  { after, illustration, title, children }: EmptyViewProps
+  { after, illustration, title, children, ...rest }: EmptyViewProps
 ) {
   const screenStyles = useStyles();
   const media = useMediaQuery();
   return (
-    <ContainerSpacious>
+    <ContainerSpacious {...rest}>
       {media === "small"
         ? (
           <ContentMedium
@@ -124,11 +127,11 @@ export function MainEmptyView(
 }
 
 export function PanelEmptyView(
-  { after, illustration, title, children }: EmptyViewProps
+  { after, illustration, title, children, ...rest }: EmptyViewProps
 ) {
   const screenStyles = useStyles();
   return (
-    <ContainerTop>
+    <ContainerTop  {...rest}>
       <ContentMedium
         illustration={illustration}
         title={title}
@@ -140,10 +143,10 @@ export function PanelEmptyView(
 }
 
 export function SubmenuEmptyView(
-  { illustration, title, children }: Omit<EmptyViewProps, "after">
+  { illustration, title, children, ...rest }: Omit<EmptyViewProps, "after">
 ) {
   return (
-    <ContainerTop>
+    <ContainerTop  {...rest}>
       <ContentSmall illustration={illustration} title={title} body={children} />
     </ContainerTop>
   );
@@ -163,11 +166,11 @@ export function SubmenuEmptyView(
  * ```
  */
 export function DialogEmptyView(
-  { after, title, children }: Omit<EmptyViewProps, "illustration">
+  { after, title, children, ...rest }: Omit<EmptyViewProps, "illustration">
 ) {
   const screenStyles = useStyles();
   return (
-    <ContainerCompact>
+    <ContainerCompact  {...rest}>
       <ContentExtraSmall title={title} body={children} />
       <div className={screenStyles.after}>{after}</div>
     </ContainerCompact>

--- a/components/empty-view/src/view.tsx
+++ b/components/empty-view/src/view.tsx
@@ -11,7 +11,7 @@ import {
 
 import { useMediaQuery } from "@axiscommunications/fluent-hooks";
 
-import { useScreenStylesStyles, useStyles } from "./styles";
+import { useContainerStyle, useStyles } from "./styles";
 import {
   ContentProps,
   EmptyViewProps,
@@ -24,7 +24,8 @@ function ContainerSpacious(
     HtmlDivAttributesRestProps
   >
 ) {
-  const { styles, containerStyle } = useScreenStylesStyles({ className });
+  const styles = useStyles()
+  const containerStyle = useContainerStyle({ className });
 
   return (
     <div className={containerStyle} {...rest}>
@@ -41,7 +42,8 @@ function ContainerCompact(
     HtmlDivAttributesRestProps
   >
 ) {
-  const { styles, containerStyle } = useScreenStylesStyles({ className });
+  const styles = useStyles()
+  const containerStyle = useContainerStyle({ className });
 
   return (
     <div className={containerStyle} {...rest}>
@@ -57,7 +59,8 @@ function ContainerTop(
     HtmlDivAttributesRestProps
   >
 ) {
-  const { styles, containerStyle } = useScreenStylesStyles({ className });
+  const styles = useStyles()
+  const containerStyle = useContainerStyle({ className });
 
   return (
     <div className={containerStyle} {...rest}>


### PR DESCRIPTION
- illustration prop is now not "string", strictly typed so you can only pick illustration supported (cant infer type, hence hardcoded list of keys)
- able to prop-drill style and classname props, so u dont have to wrap component if u want to make minor tweaks to its root style
- added media illustation to constant list


**notice**:
- we should export all illustration names from illustration repo in future, so we can use them as keys instead, but for now, constant list is fine ;)
