### PR TITLE
feat: allow custom illustration in empty view component

### DIFF
--- a/components/empty-view/src/types.ts
+++ b/components/empty-view/src/types.ts
@@ -1,4 +1,5 @@
 import { HTMLAttributes, PropsWithChildren, ReactNode } from "react";
+import { bundleIllustrationSmart } from "@axiscommunications/fluent-illustrations";
 
 export type IllustrationKind =
   | "add-user-profile"
@@ -24,14 +25,18 @@ export type IllustrationKind =
 
 export interface ContentProps {
   readonly body: ReactNode;
-  readonly illustration: IllustrationKind;
+  readonly illustration:
+    | IllustrationKind
+    | ReturnType<typeof bundleIllustrationSmart>;
   readonly title: string;
 }
 
 export type EmptyViewProps = PropsWithChildren<
   {
     readonly after?: ReactNode;
-    readonly illustration: IllustrationKind;
+    readonly illustration:
+      | IllustrationKind
+      | ReturnType<typeof bundleIllustrationSmart>;
     readonly title: string;
   } & HtmlDivAttributesRestProps
 >;

--- a/components/empty-view/src/view.tsx
+++ b/components/empty-view/src/view.tsx
@@ -72,7 +72,9 @@ function ContainerTop(
 
 function ContentLarge({ body, illustration, title }: ContentProps) {
   const screenStyles = useStyles();
-  const IllustrationComponent = Illustration[illustration];
+  const IllustrationComponent = typeof illustration === "string"
+    ? Illustration[illustration]
+    : illustration;
   return (
     <>
       <IllustrationComponent className={screenStyles.illustrationLarge} />
@@ -84,7 +86,9 @@ function ContentLarge({ body, illustration, title }: ContentProps) {
 
 function ContentMedium({ body, illustration, title }: ContentProps) {
   const screenStyles = useStyles();
-  const IllustrationComponent = Illustration[illustration];
+  const IllustrationComponent = typeof illustration === "string"
+    ? Illustration[illustration]
+    : illustration;
   return (
     <>
       <IllustrationComponent className={screenStyles.illustrationMedium} />
@@ -96,7 +100,9 @@ function ContentMedium({ body, illustration, title }: ContentProps) {
 
 function ContentSmall({ body, illustration, title }: ContentProps) {
   const screenStyles = useStyles();
-  const IllustrationComponent = Illustration[illustration];
+  const IllustrationComponent = typeof illustration === "string"
+    ? Illustration[illustration]
+    : illustration;
   return (
     <>
       <IllustrationComponent className={screenStyles.illustrationSmall} />

--- a/examples/src/stories/empty-view/examples/custom-illustration.tsx
+++ b/examples/src/stories/empty-view/examples/custom-illustration.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { MainEmptyView } from "@axiscommunications/fluent-empty-view";
+import {
+  bundleIllustrationSmart,
+  CodeErrorDark,
+  CodeErrorLight,
+} from "@axiscommunications/fluent-illustrations";
+
+const codeErrorIllustration = bundleIllustrationSmart(
+  CodeErrorDark,
+  CodeErrorLight
+);
+
+export function MainEmptyViewWithCustomIllustrationExample() {
+  return (
+    <MainEmptyView
+      illustration={codeErrorIllustration}
+      title="Unexpected error"
+    />
+  );
+}
+
+export const MainEmptyViewWithCustomIllustrationExampleAsString = `
+import React from "react";
+import { MainEmptyView } from "@axiscommunications/fluent-empty-view";
+import {
+  bundleIllustrationSmart,
+  CodeErrorDark,
+  CodeErrorLight,
+} from "@axiscommunications/fluent-illustrations";
+
+const codeErrorIllustration = bundleIllustrationSmart(CodeErrorDark, CodeErrorLight);
+
+export function MainEmptyViewWithCustomIllustrationExample() {
+  return <MainEmptyView illustration={codeErrorIllustration} title="Unexpected error" />;
+}
+`;

--- a/examples/src/stories/empty-view/page.tsx
+++ b/examples/src/stories/empty-view/page.tsx
@@ -26,6 +26,10 @@ import {
   DialogEmptyViewExample,
   DialogEmptyViewExampleAsString,
 } from "./examples/dialog";
+import {
+  MainEmptyViewWithCustomIllustrationExample,
+  MainEmptyViewWithCustomIllustrationExampleAsString,
+} from "./examples/custom-illustration";
 
 const useStyles = makeStyles({
   height: {
@@ -57,6 +61,12 @@ const examples: pageData[] = [
     anchor: "DialogEmptyViewExample",
     example: <DialogEmptyViewExample />,
     codeString: DialogEmptyViewExampleAsString,
+  },
+  {
+    title: "Main empty with with custom illustration",
+    anchor: "MainEmptyViewWithCustomIllustrationExample",
+    example: <MainEmptyViewWithCustomIllustrationExample />,
+    codeString: MainEmptyViewWithCustomIllustrationExampleAsString,
   },
 ];
 


### PR DESCRIPTION
### Describe your changes

This PR adds support for custom illustrations to be used in empty view. This allows for illustrations that are currently not part of the provided list of illustrations for empty view to be used without releasing a new version of the empty view package.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
