### PR TITLE
fix: node+browser compatible ES module import paths

### DIFF
--- a/components/empty-view/.eslintrc.json
+++ b/components/empty-view/.eslintrc.json
@@ -3,6 +3,6 @@
   "root": true,
   "ignorePatterns": ["lib", "**/*.js"],
   "parserOptions": {
-    "project": ["./tsconfig.src.json"]
+    "project": ["./tsconfig.json"]
   }
 }

--- a/components/empty-view/package.json
+++ b/components/empty-view/package.json
@@ -10,16 +10,17 @@
   },
   "license": "MIT",
   "author": "Axis Communications AB",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./lib/index.js"
+    }
+  },
+  "files": ["lib"],
   "scripts": {
     "prebuild": "pnpm run -C ../../illustrations build",
-    "build": "pnpm prebuild && pnpm build:cjs && pnpm build:esm",
-    "build:cjs": "tsc --module commonjs --outDir lib/cjs",
-    "build:esm": "tsc",
+    "build": "pnpm prebuild && tsc",
     "check:unused-deps": "depcheck . --config=depcheck.yml",
     "lint": "tsc --noEmit && eslint . --cache"
   },

--- a/components/empty-view/src/constants.ts
+++ b/components/empty-view/src/constants.ts
@@ -43,7 +43,7 @@ import {
   UnderConstructionDark,
   UnderConstructionLight,
 } from "@axiscommunications/fluent-illustrations";
-import { IllustrationKind } from "./types";
+import { IllustrationKind } from "./types.js";
 
 export const Illustration: Record<
   IllustrationKind,

--- a/components/empty-view/src/index.ts
+++ b/components/empty-view/src/index.ts
@@ -3,4 +3,4 @@ export {
   MainEmptyView,
   PanelEmptyView,
   SubmenuEmptyView,
-} from "./view";
+} from "./view.js";

--- a/components/empty-view/src/styles.ts
+++ b/components/empty-view/src/styles.ts
@@ -4,7 +4,7 @@ import {
   shorthands,
   tokens,
 } from "@fluentui/react-components";
-import { HtmlDivAttributesRestProps } from "./types";
+import { HtmlDivAttributesRestProps } from "./types.js";
 
 export const useStyles = makeStyles({
   container: {

--- a/components/empty-view/src/view.tsx
+++ b/components/empty-view/src/view.tsx
@@ -11,13 +11,13 @@ import {
 
 import { useMediaQuery } from "@axiscommunications/fluent-hooks";
 
-import { useContainerStyle, useStyles } from "./styles";
+import { useContainerStyle, useStyles } from "./styles.js";
 import {
   ContentProps,
   EmptyViewProps,
   HtmlDivAttributesRestProps,
-} from "./types";
-import { Illustration } from "./constants";
+} from "./types.js";
+import { Illustration } from "./constants.js";
 
 function ContainerSpacious(
   { children, className, ...rest }: PropsWithChildren<

--- a/components/empty-view/tsconfig.json
+++ b/components/empty-view/tsconfig.json
@@ -1,6 +1,9 @@
 {
-  "extends": "./tsconfig.src.json",
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
   "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "outDir": "lib"
   }
 }

--- a/components/empty-view/tsconfig.src.json
+++ b/components/empty-view/tsconfig.src.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../../tsconfig.base.json",
-  "include": ["src", "vitest.config.ts"]
-}

--- a/components/password-input/package.json
+++ b/components/password-input/package.json
@@ -10,8 +10,10 @@
   },
   "license": "MIT",
   "author": "Axis Communications AB",
+  "type": "module",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "require": "./lib/cjs/index.js",
       "import": "./lib/index.js"
     }
@@ -19,9 +21,7 @@
   "main": "lib/cjs/index.js",
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "build": "pnpm build:cjs && pnpm build:esm",
     "build:cjs": "tsc --module commonjs --outDir lib/cjs",

--- a/components/password-input/src/index.ts
+++ b/components/password-input/src/index.ts
@@ -1,3 +1,3 @@
-export { PasswordInput } from "./password-input";
-export { usePasswordInputStyles } from "./password-input.styles";
-export type { PasswordInputProps } from "./password-input.types";
+export { PasswordInput } from "./password-input.js";
+export { usePasswordInputStyles } from "./password-input.styles.js";
+export type { PasswordInputProps } from "./password-input.types.js";

--- a/components/password-input/src/password-input.tsx
+++ b/components/password-input/src/password-input.tsx
@@ -7,8 +7,8 @@ import {
 } from "@fluentui/react-components";
 import { EyeOffRegular, EyeRegular } from "@fluentui/react-icons";
 
-import { PasswordInputProps } from "./password-input.types";
-import { usePasswordInputStyles } from "./password-input.styles";
+import { PasswordInputProps } from "./password-input.types.js";
+import { usePasswordInputStyles } from "./password-input.styles.js";
 
 export const PasswordInput: ForwardRefComponent<PasswordInputProps> = React
   .forwardRef((props: PasswordInputProps, ref) => {

--- a/hooks/package.json
+++ b/hooks/package.json
@@ -10,22 +10,18 @@
   },
   "license": "MIT",
   "author": "Axis Communications AB",
+  "type": "module",
   "exports": {
     ".": {
       "require": "./lib/cjs/index.js",
       "import": "./lib/index.js"
     }
   },
-  "main": "lib/cjs/index.js",
-  "module": "lib/index.js",
-  "types": "lib/index.d.ts",
   "files": [
     "lib"
   ],
   "scripts": {
-    "build": "pnpm build:cjs && pnpm build:esm",
-    "build:cjs": "tsc --module commonjs --outDir lib/cjs",
-    "build:esm": "tsc",
+    "build": "tsc",
     "check:unused-deps": "depcheck . --config=depcheck.yml",
     "lint": "tsc --noEmit && eslint . --cache"
   },

--- a/hooks/src/index.ts
+++ b/hooks/src/index.ts
@@ -1,2 +1,2 @@
-export { useMediaQuery } from "./use-media-query";
-export { usePageController } from "./use-page-controller";
+export { useMediaQuery } from "./use-media-query.js";
+export { usePageController } from "./use-page-controller.js";

--- a/hooks/tsconfig.json
+++ b/hooks/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "outDir": "lib"
   },
   "include": ["src"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7288,7 +7288,7 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -7301,7 +7301,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -7332,7 +7332,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3


### PR DESCRIPTION
The packages that export ES modules do not have a `.js` extension on the import paths, which means that the import path does not match an actual file path (since the latter do have a `.js` extension). This means they cannot be properly resolved by Node.js or the browser.

However, since we're using TypeScript to transpile, and we're using the legacy "node" module resolution, the import paths are preserved and end up not having a `.js` extension, while the transpiled files to have it.

There are two main ways to deal with this:

1. Use TS configuration `{"module":"esnext","moduleResolution":"bundler"}` and use a bundler that produces import paths matching an actual file. Note: using TypeScript in this case would leave the imports as-is and require users to use a bundler, so it would not constitute an ES module that just works with node/browser, which is the problem we actually set out to solve.
2. Use TS configuration `{"module":"nodenext","moduleResolution":"nodenext"}` and use `{"type":"module"}` in package.json. This will instruct tsc to produce output that matches the package configuration, so ES module in this case.

The advantage with (1) is that it requires no addition of a `.js` extension to the imports in the .ts(x) source files. Unfortunately this requires TS 5 (we currently use TS 4) _and_ the use of a bundler to build (which we currently do not use). The advantage with (2) is that it requires no changes to how we build, but it does required adding a `.js` extension to all import paths in the source code.

Since addition of a bundler adds a layer of complexity in maintenance for a repository that should be easily accessible, it seems option (2) is preferable (and also can be done without having to do a major TS ugprade first).

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
