### PR TITLE
release: v11.0.0-alpha.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
-## [10.9.0](https://github.com/AxisCommunications/fluent-components/compare/6d32c5d4f80bd31a8280e59fc421649fc8dd976b..045f71a5054604669b74c9114f5f38d67f6d72e1) (2025-02-26T12:16:27.678Z)
+## [11.0.0-alpha.0](https://github.com/AxisCommunications/fluent-components/compare/b6f9c9f8cbe4dd8ae5a07df6dde57016a3473e09..a8eea4f973d412641ac9a2877d285e2dc4c4136e) (2025-03-11T08:34:05.001Z)
 
 ### 🚧 Maintenance
 
-  - replace eslint/dprint with biome (#396) ([52ecb1f](https://github.com/AxisCommunications/fluent-components/commit/52ecb1ffb486fa3a4b4b7d38164c7d4c2eb4fd38))
+  - fix deprecated gh action (#408) ([b6456a8](https://github.com/AxisCommunications/fluent-components/commit/b6456a824847a289b3bfb8872d75a9611f7949c6))
+  - **deps**: bump the dev-dependencies group across 1 directory with 3 updates (#407) ([797f093](https://github.com/AxisCommunications/fluent-components/commit/797f0937083236a560479558a6139c17aeadbb92))
+  - **deps**: bump @vitejs/plugin-react (#390) ([4c6b2a2](https://github.com/AxisCommunications/fluent-components/commit/4c6b2a2a2ddd0fca6dd5282d93743721cd987f09))
 
-### 💄 Styling
+### ✨ Features
 
-  - new icon (#402) ([045f71a](https://github.com/AxisCommunications/fluent-components/commit/045f71a5054604669b74c9114f5f38d67f6d72e1))
+  - **BREAKING** libraries only export (valid) ES modules (#405) ([8f8b0bc](https://github.com/AxisCommunications/fluent-components/commit/8f8b0bcdeba6fca841748b7171702afb2e08469b))
+
+### 🐛 Bug fixes
+
+  - allow "alpha" prereleases ([a8eea4f](https://github.com/AxisCommunications/fluent-components/commit/a8eea4f973d412641ac9a2877d285e2dc4c4136e))

--- a/components/empty-view/package.json
+++ b/components/empty-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiscommunications/fluent-empty-view",
-  "version": "10.9.0",
+  "version": "11.0.0-alpha.0",
   "description": "Empty view for Fluent UI v9",
   "homepage": "https://github.com/AxisCommunications/fluent-components#readme",
   "repository": {

--- a/components/password-input/package.json
+++ b/components/password-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiscommunications/fluent-password-input",
-  "version": "10.9.0",
+  "version": "11.0.0-alpha.0",
   "description": "Password input for Fluent UI v9",
   "homepage": "https://github.com/AxisCommunications/fluent-components#readme",
   "repository": {

--- a/components/slider/package.json
+++ b/components/slider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiscommunications/fluent-slider",
-  "version": "10.9.0",
+  "version": "11.0.0-alpha.0",
   "description": "Axis branded Slider",
   "homepage": "https://github.com/AxisCommunications/fluent-components#readme",
   "repository": {

--- a/components/stepper/package.json
+++ b/components/stepper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiscommunications/fluent-stepper",
-  "version": "10.9.0",
+  "version": "11.0.0-alpha.0",
   "description": "Stepper for Fluent UI v9",
   "homepage": "https://github.com/AxisCommunications/fluent-components#readme",
   "repository": {

--- a/components/topbar/package.json
+++ b/components/topbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiscommunications/fluent-topbar",
-  "version": "10.9.0",
+  "version": "11.0.0-alpha.0",
   "description": "Axis branded TopBar",
   "homepage": "https://github.com/AxisCommunications/fluent-components#readme",
   "repository": {

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "examples",
-  "version": "10.9.0",
+  "version": "11.0.0-alpha.0",
   "private": true,
   "description": "Examples for Fluent UI v9",
   "homepage": "https://github.com/AxisCommunications/fluent-components#readme",

--- a/hooks/package.json
+++ b/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiscommunications/fluent-hooks",
-  "version": "10.9.0",
+  "version": "11.0.0-alpha.0",
   "description": "Hooks",
   "homepage": "https://github.com/AxisCommunications/fluent-components#readme",
   "repository": {

--- a/icons/package.json
+++ b/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiscommunications/fluent-icons",
-  "version": "10.9.0",
+  "version": "11.0.0-alpha.0",
   "description": "Icons",
   "homepage": "https://github.com/AxisCommunications/fluent-components#readme",
   "repository": {

--- a/illustrations/package.json
+++ b/illustrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiscommunications/fluent-illustrations",
-  "version": "10.9.0",
+  "version": "11.0.0-alpha.0",
   "description": "Illustrations",
   "homepage": "https://github.com/AxisCommunications/fluent-components#readme",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiscommunications/fluent-components",
-  "version": "10.9.0",
+  "version": "11.0.0-alpha.0",
   "private": true,
   "description": "Axis branded theme, components and examples for Fluent UI v9",
   "repository": {

--- a/styles/package.json
+++ b/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiscommunications/fluent-styles",
-  "version": "10.9.0",
+  "version": "11.0.0-alpha.0",
   "description": "Styles for Fluent UI v9",
   "homepage": "https://github.com/AxisCommunications/fluent-components#readme",
   "repository": {

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiscommunications/fluent-theme",
-  "version": "10.9.0",
+  "version": "11.0.0-alpha.0",
   "description": "Theme for Fluent UI v9",
   "homepage": "https://github.com/AxisCommunications/fluent-components#readme",
   "repository": {

--- a/tools/generated/release/release.js
+++ b/tools/generated/release/release.js
@@ -23,7 +23,12 @@ export function release(increment) {
   const { version, repository } = JSON.parse(
     readFileSync("package.json").toString()
   );
-  const nextVersion = semver.inc(version, releaseType);
+  const isPre = releaseType.startsWith("pre");
+  const nextVersion = semver.inc(
+    version,
+    releaseType,
+    isPre ? "alpha" : undefined
+  );
   if (nextVersion === null) {
     throw new Error(`could not increment ${version} with ${releaseType}`);
   }

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tools",
-  "version": "10.9.0",
+  "version": "11.0.0-alpha.0",
   "private": true,
   "author": "Axis Communications AB",
   "type": "module",

--- a/tools/src/release/release.ts
+++ b/tools/src/release/release.ts
@@ -27,7 +27,12 @@ export function release(increment: string) {
   const { version, repository } = JSON.parse(
     readFileSync("package.json").toString()
   );
-  const nextVersion = semver.inc(version, releaseType);
+  const isPre = releaseType.startsWith("pre");
+  const nextVersion = semver.inc(
+    version,
+    releaseType,
+    isPre ? "alpha" : undefined
+  );
   if (nextVersion === null) {
     throw new Error(`could not increment ${version} with ${releaseType}`);
   }


### PR DESCRIPTION
- fix to use "alpha" when using any prerelease (so that it's
  correctly tagged as "next" when publishing)
- release new breaking changes