### PR TITLE
chore: enable search by token value for example page

### DIFF
--- a/examples/src/stories/theme/components/color-tokens.tsx
+++ b/examples/src/stories/theme/components/color-tokens.tsx
@@ -52,7 +52,14 @@ export function ColorTokens({ theme, filter, ...rest }: TColorTokens) {
 
   const tokens = Object.entries(light)
     .filter(([token]) => token.startsWith("color"))
-    .filter(([token]) => token.toLowerCase().includes(filter.toLowerCase()))
+    .filter(([token, value]) => {
+      const keyHit = token.toLowerCase().includes(filter.toLowerCase());
+      const valueHit = value
+        .toString()
+        .toLowerCase()
+        .includes(filter.toLowerCase());
+      return keyHit || valueHit;
+    })
     .map(([token, value]) => ({
       token,
       lightValue: value as string,


### PR DESCRIPTION
There is not possible to filter tokens by value today from examplepage.
This small addition makes this possible