### PR TITLE
chore(styles): use standard styles for scrollbar

### DIFF
--- a/styles/src/static/static.styles.ts
+++ b/styles/src/static/static.styles.ts
@@ -2,24 +2,9 @@ import { makeStaticStyles, tokens } from "@fluentui/react-components";
 
 const scrollbarColor = tokens.colorScrollbarOverlay;
 
-const isFirefox = window.navigator.userAgent.includes("Fire");
 export const useScrollStaticStyles = makeStaticStyles({
   "*": {
-    // Firefox
-    // Scrollbar styling is amazingly complex. Read more here:
-    // https://stackoverflow.com/questions/6165472/custom-css-scrollbar-for-firefox
-    scrollbarWidth: isFirefox ? "thin" : "unset",
-    scrollbarColor: isFirefox ? `${scrollbarColor} transparent` : "auto",
-  },
-  "*::-webkit-scrollbar": {
-    width: tokens.spacingHorizontalSNudge,
-    height: tokens.spacingHorizontalSNudge,
-  },
-  "*::-webkit-scrollbar-thumb": {
-    background: scrollbarColor,
-    borderRadius: tokens.borderRadiusXLarge,
-  },
-  "*::-webkit-scrollbar-track": {
-    background: "none",
+    scrollbarWidth: "thin",
+    scrollbarColor: `${scrollbarColor} transparent`,
   },
 });


### PR DESCRIPTION
- Uses only standard css for scrollbar.
- This change allows us to use the Fluent `useScrollbarWidth` hook if needed.

### Describe your changes

#### Chrome:
Before
![chrome-before](https://github.com/user-attachments/assets/c753617e-db06-4378-8405-af29ca16e5ee)

After -  Get arrows above/below scrollbar.
![chrome-after](https://github.com/user-attachments/assets/4aab628c-97a7-4095-a61e-be30358409b9)

#### Firefox: 
After -  Looks the same as before
![firefox-after](https://github.com/user-attachments/assets/14094277-6a4c-4fb0-9aa1-c8c3d8584468)

#### Safari:
`scrollbar-color` is not supported on Safari yet so the color is not the specified color. 
And it is shown only when the user scrolls the content.
(I didn't test it on the example page on Safari because I use Linux. But tested on the other app.)

#### Electron (Chromium):
Get arrows above/below scrollbar. Scrollbar edge is square.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
