### PR TITLE
feat(topbar): add optional initials for user avatar

### DIFF
--- a/components/topbar/src/profile-menu.tsx
+++ b/components/topbar/src/profile-menu.tsx
@@ -31,6 +31,7 @@ export const ProfileMenu = ({
   language,
   name,
   email,
+  initials,
   onSignOut,
   signOutLabel,
   tag,
@@ -50,6 +51,7 @@ export const ProfileMenu = ({
             <Avatar
               color="mink"
               name={name}
+              initials={initials}
               size={24}
               badge={
                 hasNotification
@@ -79,7 +81,12 @@ export const ProfileMenu = ({
       </MenuTrigger>
       <MenuPopover>
         <MenuList>
-          <UserInformation name={name} email={email} tag={tag} />
+          <UserInformation
+            name={name}
+            email={email}
+            initials={initials}
+            tag={tag}
+          />
           {(customContent === undefined || showCustomContentTopDivider) && (
             <MenuDivider />
           )}

--- a/components/topbar/src/profile-menu.types.ts
+++ b/components/topbar/src/profile-menu.types.ts
@@ -27,6 +27,8 @@ export type UserInformationProps = {
   readonly email: string;
   // Optional third tagline (for extra information)
   readonly tag?: string;
+  // Optional custom initials for avatar
+  readonly initials?: string;
 };
 
 export type ProfileMenuProps = UserInformationProps & {

--- a/components/topbar/src/profile-user-information.tsx
+++ b/components/topbar/src/profile-user-information.tsx
@@ -3,12 +3,19 @@ import React from "react";
 import { UserInformationProps } from "./profile-menu.types";
 import { useUserInfoStyles } from "./profile-user-information.styles";
 
-export const UserInformation = ({ name, email, tag }: UserInformationProps) => {
+export const UserInformation = ({
+  name,
+  email,
+  initials,
+  tag,
+}: UserInformationProps) => {
   const styles = useUserInfoStyles();
 
   return (
     <div className={styles.root}>
       <Persona
+        data-testid="profile-menu-persona"
+        avatar={{ initials: initials }}
         name={name}
         secondaryText={email}
         size="large"

--- a/components/topbar/src/top-bar.spec.tsx
+++ b/components/topbar/src/top-bar.spec.tsx
@@ -1,5 +1,5 @@
 import { render } from "@testing-library/react";
-import React from "react";
+import React, { act } from "react";
 import { TopBar } from "./top-bar";
 
 describe("Topbar", () => {
@@ -64,5 +64,55 @@ describe("Topbar", () => {
 
     const appMenuButton = await findByTestId("application-drawer-trigger");
     expect(appMenuButton).toBeTruthy();
+  });
+
+  it("should render standard initials", async () => {
+    const { findByTestId } = render(
+      <TopBar
+        profileMenu={{
+          name: "Super User",
+          email: "super.user@axis.com",
+          language: { onChange: () => {}, value: "en" },
+          theme: { onChange: () => {}, value: "dark" },
+          onSignOut: () => {},
+        }}
+      />
+    );
+
+    const profileMenuButton = await findByTestId("profile-menu-button");
+    expect(profileMenuButton).toHaveTextContent("SU");
+
+    act(() => {
+      profileMenuButton.click();
+    });
+    const profileMenuPersona = await findByTestId("profile-menu-persona");
+    expect(profileMenuPersona).toHaveTextContent(
+      "SUSuper Usersuper.user@axis.com"
+    );
+  });
+
+  it("should render custom initials", async () => {
+    const { findByTestId } = render(
+      <TopBar
+        profileMenu={{
+          name: "Super User",
+          email: "super.user@axis.com",
+          initials: "XY",
+          language: { onChange: () => {}, value: "en" },
+          theme: { onChange: () => {}, value: "dark" },
+          onSignOut: () => {},
+        }}
+      />
+    );
+
+    const profileMenuButton = await findByTestId("profile-menu-button");
+    expect(profileMenuButton).toHaveTextContent("XY");
+    act(() => {
+      profileMenuButton.click();
+    });
+    const profileMenuPersona = await findByTestId("profile-menu-persona");
+    expect(profileMenuPersona).toHaveTextContent(
+      "XYSuper Usersuper.user@axis.com"
+    );
   });
 });


### PR DESCRIPTION
### Describe your changes

Add optional property to topbar to set custom initials for user avatar.

Initials set:
<img width="264" height="112" alt="image" src="https://github.com/user-attachments/assets/c64fe8c6-dc5f-477d-9c0f-19448e1840df" />

Initials not set:
<img width="267" height="109" alt="image" src="https://github.com/user-attachments/assets/a2bca271-4a04-4fa0-8ded-86a3760b3ccf" />

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
