### PR TITLE
chore(deps): remove react-theme as peer dependency

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -51,7 +51,6 @@
   },
   "peerDependencies": {
     "@fluentui/react-components": "^9.62.0",
-    "@fluentui/react-theme": "^9.1.24",
     "react": ">=16.8.0 <19.0.0",
     "react-dom": ">=16.8.0 <19.0.0"
   },


### PR DESCRIPTION
@fluentui/react-theme should not be a peer dependency in addition to
being a dev dependency. Host applications will use this package and have
no need for @fluentui/react-theme.
