### PR TITLE
fix(slider): calculate label width prevent overflow

### DIFF
--- a/components/slider/src/mark/label/mark-label.spec.tsx
+++ b/components/slider/src/mark/label/mark-label.spec.tsx
@@ -1,0 +1,114 @@
+import { act, render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Slider } from "../../slider";
+import { sliderClassNames } from "../../use-slider-styles";
+
+type ResizeCallback = (entries: ResizeObserverEntry[]) => void;
+
+let resizeCallbacks: ResizeCallback[] = [];
+let observedElements: Element[] = [];
+const disconnectFn = vi.fn();
+
+class MockResizeObserver {
+  constructor(callback: ResizeCallback) {
+    resizeCallbacks.push(callback);
+  }
+
+  observe(el: Element) {
+    observedElements.push(el);
+  }
+
+  disconnect() {
+    disconnectFn();
+    observedElements = [];
+  }
+
+  unobserve() {}
+}
+
+describe("mark label", () => {
+  beforeEach(() => {
+    vi.stubGlobal("ResizeObserver", MockResizeObserver);
+    observedElements = [];
+    resizeCallbacks = [];
+    disconnectFn.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const renderSliderWithLabels = (marks: { value: number; label: string }[]) =>
+    render(<Slider min={0} max={100} marks={marks} data-testid="slider" />);
+
+  it("should render mark labels", () => {
+    const { getByTestId } = renderSliderWithLabels([
+      { value: 0, label: "min" },
+      { value: 50, label: "mid" },
+      { value: 100, label: "max" },
+    ]);
+
+    const root = getByTestId("slider");
+    const labels = root.querySelectorAll(`.${sliderClassNames.mark.label}`);
+    expect(labels).toHaveLength(3);
+    expect(labels[0].textContent).toBe("min");
+    expect(labels[1].textContent).toBe("mid");
+    expect(labels[2].textContent).toBe("max");
+  });
+
+  it("should observe mark label elements with ResizeObserver", () => {
+    const { getByTestId } = renderSliderWithLabels([
+      { value: 0, label: "start" },
+      { value: 100, label: "end" },
+    ]);
+
+    const root = getByTestId("slider");
+    const labels = root.querySelectorAll(`.${sliderClassNames.mark.label}`);
+
+    expect(resizeCallbacks).toHaveLength(labels.length);
+    expect(observedElements).toHaveLength(labels.length);
+    for (let i = 0; i < labels.length; i++) {
+      expect(observedElements[i]).toBe(labels[i]);
+    }
+  });
+
+  it("should update labelWidth when ResizeObserver fires", () => {
+    const { getByTestId } = renderSliderWithLabels([
+      { value: 50, label: "center" },
+    ]);
+
+    const root = getByTestId("slider");
+    const label = root.querySelector(
+      `.${sliderClassNames.mark.label}`
+    ) as HTMLElement;
+
+    // Simulate ResizeObserver reporting a width change
+    Object.defineProperty(label, "clientWidth", {
+      value: 80,
+      configurable: true,
+    });
+    act(() => {
+      for (const cb of resizeCallbacks) {
+        cb([{ target: label } as unknown as ResizeObserverEntry]);
+      }
+    });
+
+    // After ResizeObserver fires, the label should still be rendered
+    const updatedLabel = root.querySelector(
+      `.${sliderClassNames.mark.label}`
+    ) as HTMLElement;
+    expect(updatedLabel).toBeTruthy();
+    expect(updatedLabel.textContent).toBe("center");
+  });
+
+  it("should disconnect ResizeObserver on unmount", () => {
+    const { unmount } = renderSliderWithLabels([{ value: 50, label: "test" }]);
+
+    expect(disconnectFn).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(disconnectFn).toHaveBeenCalled();
+  });
+});

--- a/components/slider/src/mark/label/mark-label.types.ts
+++ b/components/slider/src/mark/label/mark-label.types.ts
@@ -21,4 +21,5 @@ export type MarkLabelState = ComponentState<MarkLabelSlots> &
     offset: number;
     disabled: boolean;
     active: boolean;
+    labelWidth: number;
   };

--- a/components/slider/src/mark/label/use-mark-label-styles.ts
+++ b/components/slider/src/mark/label/use-mark-label-styles.ts
@@ -24,7 +24,6 @@ const useStyles = makeStyles({
     position: "absolute",
     color: `var(${sliderVars.mark.color})`,
     top: `var(${sliderVars.thumb.size})`,
-    transform: `translateX(-50%)`,
     whiteSpace: "nowrap",
   },
   active: {
@@ -43,7 +42,7 @@ export const useMarkLabelStyles_unstable = (
 ): MarkLabelState => {
   const styles = useStyles();
 
-  const { offset, disabled, active } = state;
+  const { offset, disabled, active, labelWidth } = state;
 
   const colorStyles = disabled
     ? styles.disabled
@@ -60,7 +59,11 @@ export const useMarkLabelStyles_unstable = (
 
   const { dir } = useFluent();
   const offsetDirection = dir === "rtl" ? "right" : "left";
-  state.root.style = { [offsetDirection]: `${offset}%`, ...state.root.style };
+  const clampedPosition = `clamp(0%, calc(${offset}% - ${labelWidth / 2}px), calc(100% - ${labelWidth}px))`;
+  state.root.style = {
+    [offsetDirection]: clampedPosition,
+    ...state.root.style,
+  };
 
   return state;
 };

--- a/components/slider/src/mark/label/use-mark-label.ts
+++ b/components/slider/src/mark/label/use-mark-label.ts
@@ -1,5 +1,8 @@
-import { getNativeElementProps } from "@fluentui/react-utilities";
-import React from "react";
+import {
+  getNativeElementProps,
+  useMergedRefs,
+} from "@fluentui/react-utilities";
+import React, { useLayoutEffect, useRef, useState } from "react";
 
 import { useSliderContext } from "../../context/slider-context";
 import { toPercent } from "../../utils";
@@ -18,9 +21,35 @@ export const useMarkLabel_unstable = (
     ? values.some((value) => value === props.value)
     : props.value >= minValue && props.value <= maxValue;
 
+  const [labelWidth, setLabelWidth] = useState(0);
+  const el = useRef<HTMLElement | null>(null);
+  const labelRef = useMergedRefs(ref, el);
+
+  useLayoutEffect(() => {
+    const element = el.current;
+    if (element === null) {
+      return;
+    }
+    setLabelWidth(element.clientWidth);
+
+    if (typeof window.ResizeObserver === "undefined") {
+      return;
+    }
+    const observer = new window.ResizeObserver((entries) => {
+      if (entries === undefined || entries.length === 0) {
+        return;
+      }
+      for (const entry of entries) {
+        setLabelWidth(entry.target.clientWidth);
+      }
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
   return {
     root: getNativeElementProps("span", {
-      ref,
+      ref: labelRef,
       children: props.label,
       ...props,
     }),
@@ -31,5 +60,6 @@ export const useMarkLabel_unstable = (
     value: props.value,
     disabled,
     active,
+    labelWidth,
   };
 };

--- a/examples/src/stories/slider/examples/stepping-to-marks-example.tsx
+++ b/examples/src/stories/slider/examples/stepping-to-marks-example.tsx
@@ -9,9 +9,11 @@ export function SteppingToMarksSliderExample() {
       defaultValue={50}
       step="marks"
       marks={[
+        { value: 0, label: "min" },
         { value: 25 },
         { value: 50, label: "50" },
         { value: 75, label: "75" },
+        { value: 100, label: "max" },
       ]}
     />
   );
@@ -28,9 +30,11 @@ export function SteppingToMarksSliderExample() {
       defaultValue={50}
       step="marks"
       marks={[
+        { value: 0, label: "min" },
         { value: 25 },
         { value: 50, label: "50" },
         { value: 75, label: "75" },
+        { value: 100, label: "max" },
       ]} />
   )
 }


### PR DESCRIPTION
* Calculate the width of the mark label and use it to prevent overflow when the label is near the edges of the slider.
* Add observer to update label width on resize.
* Add tests to verify that the label width is calculated and applied correctly.

Thanks for starting a pull request (PR) in this repository!

## Describe your changes

<!--
Tell us about the change. Why did you make it and what does it do?
-->

Calculate the width of the mark label and use it to prevent overflow when the label is near the edges of the slider.

## Related issue

<!--
If this is a relatively large or complex proposal, kick off the discussion by creating a new issue and do not open a PR immediately. Explain the problem you're facing and potential alternatives you've considered.

If this PR relates to such an issue, please share it here. If not, feel free to remove this section.
-->

The issue:

<img width="1177" height="269" alt="Screenshot from 2026-05-27 16-10-05" src="https://github.com/user-attachments/assets/6e482483-a1ba-4eaf-ba34-a91741a9b5af" />
## Checklist before asking for a review

<!--
Mark the boxes that apply with an 'x'. You can also fill these out after creating the PR. If you're unsure about any, just ask. We're here to help! This is just a reminder of what we're looking for before merging your changes.
-->

- [X] I've reviewed my own changes
- [X] I've made sure my changes align with the existing style in the repository
