### PR TITLE
feat(examples): modernize navigation, landing, and theme pages

### DIFF
--- a/examples/src/components/copy-button.tsx
+++ b/examples/src/components/copy-button.tsx
@@ -1,0 +1,83 @@
+import {
+  Button,
+  ButtonProps,
+  Tooltip,
+  makeStyles,
+  mergeClasses,
+  tokens,
+} from "@fluentui/react-components";
+import { CheckmarkRegular, CopyRegular } from "@fluentui/react-icons";
+import { MouseEvent, useCallback, useState } from "react";
+
+const useStyles = makeStyles({
+  root: {
+    color: tokens.colorNeutralForeground3,
+    ":hover": {
+      color: tokens.colorNeutralForeground1,
+    },
+  },
+  copied: {
+    color: tokens.colorStatusSuccessForeground1,
+    ":hover": {
+      color: tokens.colorStatusSuccessForeground1,
+    },
+  },
+});
+
+export type CopyButtonProps = {
+  /** The text to write to the clipboard. */
+  value: string;
+  /** Tooltip/aria label shown in the idle state. */
+  copyLabel?: string;
+  /** Tooltip/aria label shown briefly after a successful copy. */
+  copiedLabel?: string;
+  className?: string;
+} & Pick<ButtonProps, "shape" | "appearance" | "size">;
+
+export function CopyButton({
+  value,
+  copyLabel = "Copy",
+  copiedLabel = "Copied!",
+  className,
+  appearance = "subtle",
+  ...rest
+}: CopyButtonProps) {
+  const styles = useStyles();
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = useCallback(
+    async (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      event.preventDefault();
+      try {
+        await navigator.clipboard.writeText(value);
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1200);
+      } catch (error) {
+        console.error("Error copying to clipboard:", error);
+      }
+    },
+    [value]
+  );
+
+  return (
+    <Tooltip
+      withArrow
+      relationship="label"
+      content={copied ? copiedLabel : copyLabel}
+    >
+      <Button
+        appearance={appearance}
+        aria-label={copied ? copiedLabel : copyLabel}
+        icon={copied ? <CheckmarkRegular /> : <CopyRegular />}
+        className={mergeClasses(
+          styles.root,
+          copied && styles.copied,
+          className
+        )}
+        onClick={onCopy}
+        {...rest}
+      />
+    </Tooltip>
+  );
+}

--- a/examples/src/components/main-menu/main-menu.tsx
+++ b/examples/src/components/main-menu/main-menu.tsx
@@ -7,6 +7,9 @@ import {
   Tab,
   TabList,
   TabProps,
+  makeStyles,
+  mergeClasses,
+  tokens,
   useTabListContext_unstable,
 } from "@fluentui/react-components";
 import {
@@ -28,6 +31,12 @@ const SettingsIcon = bundleIcon(SettingsFilled, SettingsRegular);
 
 const HOME_VALUE = "1";
 
+const useOverrideStyles = makeStyles({
+  container: {
+    backgroundColor: tokens.colorNeutralBackground2,
+  },
+});
+
 export function MainMenu() {
   const [selectedTab, setSelectedTab] = useState(HOME_VALUE);
   const navigate = useNavigate();
@@ -39,11 +48,12 @@ export function MainMenu() {
     }
   }, [pathname]);
 
+  const overrides = useOverrideStyles();
   const { rootStyle: containerRootStyle } = useMainMenuContainerStyles();
   const { rootStyle, spacerStyle } = useMainMenuTabListStyles();
 
   return (
-    <div className={containerRootStyle}>
+    <div className={mergeClasses(containerRootStyle, overrides.container)}>
       <TabList
         className={rootStyle}
         size="large"

--- a/examples/src/components/navigation-menu/navigation-menu.tsx
+++ b/examples/src/components/navigation-menu/navigation-menu.tsx
@@ -1,75 +1,256 @@
 import {
   Caption1,
   Link,
-  NavCategory,
-  NavCategoryItem,
-  NavDrawer,
-  NavDrawerBody,
-  NavDrawerFooter,
-  NavItem,
-  NavSubItem,
-  NavSubItemGroup,
   makeStyles,
   mergeClasses,
   shorthands,
   tokens,
 } from "@fluentui/react-components";
 import {
+  BeachFilled,
   BeachRegular,
+  ChevronRightRegular,
+  DarkThemeFilled,
   DarkThemeRegular,
+  DocumentCssFilled,
+  DocumentCssRegular,
+  FluentIcon,
+  IconsFilled,
   IconsRegular,
+  PuzzlePieceFilled,
   PuzzlePieceRegular,
-  SlideTextRegular,
 } from "@fluentui/react-icons";
-import { useCallback } from "react";
+import { useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { GitHubUrls } from "../../constants/constants";
-import { routes } from "../../routing/routes";
+import { TRoute, routes } from "../../routing/routes";
 
 const componentId = "navigation-menu";
 export const navigationMenuClassNames = {
   root: componentId,
 };
 
+type NavLink = {
+  label: string;
+  route: TRoute;
+};
+
+type NavItemDef = NavLink & {
+  icon: FluentIcon;
+  activeIcon: FluentIcon;
+};
+
+type NavGroupDef = {
+  id: string;
+  label: string;
+  icon: FluentIcon;
+  activeIcon: FluentIcon;
+  items: NavLink[];
+};
+
+const topLevelItems: NavItemDef[] = [
+  {
+    label: "Themes",
+    route: routes.Theme,
+    icon: DarkThemeRegular,
+    activeIcon: DarkThemeFilled,
+  },
+  {
+    label: "Icons",
+    route: routes.IconCatalog,
+    icon: IconsRegular,
+    activeIcon: IconsFilled,
+  },
+  {
+    label: "Illustrations",
+    route: routes.Illustrations,
+    icon: BeachRegular,
+    activeIcon: BeachFilled,
+  },
+];
+
+const groups: NavGroupDef[] = [
+  {
+    id: "components",
+    label: "Components",
+    icon: PuzzlePieceRegular,
+    activeIcon: PuzzlePieceFilled,
+    items: [
+      { label: "Stepper", route: routes.Stepper },
+      { label: "Slider", route: routes.Slider },
+      { label: "Password input", route: routes.PasswordInput },
+      { label: "Empty view", route: routes.EmptyView },
+    ],
+  },
+  {
+    id: "styles",
+    label: "Styles",
+    icon: DocumentCssRegular,
+    activeIcon: DocumentCssFilled,
+    items: [
+      { label: "Main menu", route: routes.mainMenu },
+      { label: "Table", route: routes.TableUtilities },
+      { label: "Tablist", route: routes.TabListUtilities },
+    ],
+  },
+];
+
 const useStyles = makeStyles({
   root: {
+    display: "flex",
+    flexDirection: "column",
+    boxSizing: "border-box",
     height: "100%",
-    width: "280px",
-    ...shorthands.border(0),
+    width: "236px",
+    backgroundColor: tokens.colorNeutralBackground2,
   },
   body: {
-    ...shorthands.padding(tokens.spacingVerticalXS, tokens.spacingHorizontalS),
+    display: "flex",
+    flexDirection: "column",
+    flexGrow: 1,
+    ...shorthands.gap("2px"),
+    ...shorthands.padding(tokens.spacingVerticalM, tokens.spacingHorizontalM),
+    overflowY: "auto",
+    overflowX: "hidden",
   },
-  subItemGroup: {
+  item: {
+    position: "relative",
+    display: "flex",
+    alignItems: "center",
+    width: "100%",
+    height: "38px",
+    ...shorthands.gap(tokens.spacingHorizontalM),
+    ...shorthands.padding(0, tokens.spacingHorizontalM),
+    ...shorthands.border(0),
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    backgroundColor: "transparent",
+    color: tokens.colorNeutralForeground2,
+    fontFamily: tokens.fontFamilyBase,
+    fontSize: tokens.fontSizeBase300,
+    lineHeight: tokens.lineHeightBase300,
+    textAlign: "left",
+    cursor: "pointer",
+    transitionDuration: tokens.durationFaster,
+    transitionProperty: "background-color, color",
+    ":hover": {
+      backgroundColor: tokens.colorNeutralBackground2Hover,
+      color: tokens.colorNeutralForeground1,
+    },
+    ":active": {
+      backgroundColor: tokens.colorNeutralBackground2Pressed,
+    },
+  },
+  itemActive: {
+    backgroundColor: tokens.colorBrandBackground2,
+    color: tokens.colorBrandForeground1,
+    fontWeight: tokens.fontWeightSemibold,
+    ":hover": {
+      backgroundColor: tokens.colorBrandBackground2,
+      color: tokens.colorBrandForeground1,
+    },
+    "::before": {
+      content: '""',
+      position: "absolute",
+      left: "3px",
+      top: "9px",
+      bottom: "9px",
+      width: "3px",
+      ...shorthands.borderRadius(tokens.borderRadiusCircular),
+      backgroundColor: tokens.colorBrandForeground1,
+    },
+  },
+  icon: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+    width: "20px",
+    height: "20px",
+    fontSize: "20px",
+  },
+  label: {
+    flexGrow: 1,
+    ...shorthands.overflow("hidden"),
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  chevron: {
+    flexShrink: 0,
+    fontSize: "16px",
+    color: tokens.colorNeutralForeground3,
+    transitionDuration: tokens.durationFaster,
+    transitionProperty: "transform",
+  },
+  chevronOpen: {
+    transform: "rotate(90deg)",
+  },
+  group: {
+    display: "flex",
+    flexDirection: "column",
+    ...shorthands.gap("2px"),
+  },
+  subGroup: {
+    display: "flex",
+    flexDirection: "column",
+    ...shorthands.gap("2px"),
+    marginTop: "2px",
+    marginLeft: "26px",
+    paddingLeft: tokens.spacingHorizontalS,
     ...shorthands.borderLeft(
       tokens.strokeWidthThin,
       "solid",
       tokens.colorNeutralStroke2
     ),
-    marginLeft: "28px",
-    "& .fui-NavSubItem": {
-      fontSize: tokens.fontSizeBase200,
-      color: tokens.colorNeutralForeground3,
-    },
-    "& .fui-NavSubItem:hover": {
+  },
+  subItem: {
+    display: "flex",
+    alignItems: "center",
+    width: "100%",
+    height: "32px",
+    ...shorthands.padding(0, tokens.spacingHorizontalM),
+    ...shorthands.border(0),
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    backgroundColor: "transparent",
+    color: tokens.colorNeutralForeground3,
+    fontFamily: tokens.fontFamilyBase,
+    fontSize: tokens.fontSizeBase200,
+    textAlign: "left",
+    cursor: "pointer",
+    transitionDuration: tokens.durationFaster,
+    transitionProperty: "background-color, color",
+    ":hover": {
+      backgroundColor: tokens.colorNeutralBackground2Hover,
       color: tokens.colorNeutralForeground1,
     },
-    "& .fui-NavSubItem[aria-current='page']": {
-      color: tokens.colorNeutralForeground1,
-      fontWeight: tokens.fontWeightSemibold,
+  },
+  subItemActive: {
+    backgroundColor: tokens.colorBrandBackground2,
+    color: tokens.colorBrandForeground1,
+    fontWeight: tokens.fontWeightSemibold,
+    ":hover": {
+      backgroundColor: tokens.colorBrandBackground2,
+      color: tokens.colorBrandForeground1,
     },
   },
   footer: {
     display: "flex",
     alignItems: "center",
     ...shorthands.gap(tokens.spacingHorizontalS),
-    ...shorthands.padding(tokens.spacingVerticalM, tokens.spacingHorizontalL),
+    ...shorthands.padding(tokens.spacingVerticalM, tokens.spacingHorizontalXL),
+    ...shorthands.borderTop(
+      tokens.strokeWidthThin,
+      "solid",
+      tokens.colorNeutralStroke2
+    ),
   },
   footerIcon: {
+    display: "inline-flex",
+    color: tokens.colorNeutralForeground3,
     transitionDuration: tokens.durationNormal,
-    transitionProperty: "transform",
+    transitionProperty: "transform, color",
     ":hover": {
-      transform: "scale(1.15) rotate(10deg)",
+      color: tokens.colorNeutralForeground1,
+      transform: "scale(1.12) rotate(8deg)",
     },
   },
   footerText: {
@@ -77,69 +258,101 @@ const useStyles = makeStyles({
   },
 });
 
-export function useNavigationMenuStyles() {
+export function NavigationMenu() {
   const styles = useStyles();
-  const rootStyle = mergeClasses(navigationMenuClassNames.root, styles.root);
-  return { styles, rootStyle };
-}
-
-export function NavigationMenu({ ...rest }) {
-  const { styles, rootStyle } = useNavigationMenuStyles();
   const navigate = useNavigate();
   const { pathname } = useLocation();
 
-  const handleNavSelect = useCallback(
-    (_: unknown, data: { value: string }) => {
-      navigate(data.value);
-    },
-    [navigate]
+  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>(() => {
+    const initial: Record<string, boolean> = {};
+    for (const group of groups) {
+      initial[group.id] = true;
+    }
+    return initial;
+  });
+
+  const toggleGroup = (id: string) =>
+    setOpenGroups((prev) => ({ ...prev, [id]: !prev[id] }));
+
+  const rootStyle = useMemo(
+    () => mergeClasses(navigationMenuClassNames.root, styles.root),
+    [styles.root]
   );
 
   return (
-    <NavDrawer
-      data-testid={componentId}
-      open={true}
-      type="inline"
-      className={rootStyle}
-      selectedValue={pathname}
-      onNavItemSelect={handleNavSelect}
-      defaultOpenCategories={["components", "styles"]}
-      multiple
-      {...rest}
-    >
-      <NavDrawerBody className={styles.body}>
-        <NavItem icon={<DarkThemeRegular />} value={routes.Theme}>
-          Themes
-        </NavItem>
-        <NavItem icon={<IconsRegular />} value={routes.IconCatalog}>
-          Icons
-        </NavItem>
-        <NavItem icon={<BeachRegular />} value={routes.Illustrations}>
-          Illustrations
-        </NavItem>
+    <nav data-testid={componentId} className={rootStyle}>
+      <div className={styles.body}>
+        {topLevelItems.map((item) => {
+          const active = pathname === item.route;
+          const Icon = active ? item.activeIcon : item.icon;
+          return (
+            <button
+              key={item.route}
+              type="button"
+              aria-current={active ? "page" : undefined}
+              className={mergeClasses(styles.item, active && styles.itemActive)}
+              onClick={() => navigate(item.route)}
+            >
+              <span className={styles.icon}>
+                <Icon />
+              </span>
+              <span className={styles.label}>{item.label}</span>
+            </button>
+          );
+        })}
 
-        <NavCategory value="components">
-          <NavCategoryItem icon={<PuzzlePieceRegular />}>
-            Components
-          </NavCategoryItem>
-          <NavSubItemGroup className={styles.subItemGroup}>
-            <NavSubItem value={routes.Stepper}>Stepper</NavSubItem>
-            <NavSubItem value={routes.Slider}>Slider</NavSubItem>
-            <NavSubItem value={routes.PasswordInput}>Password input</NavSubItem>
-            <NavSubItem value={routes.EmptyView}>Empty view</NavSubItem>
-          </NavSubItemGroup>
-        </NavCategory>
+        {groups.map((group) => {
+          const isOpen = openGroups[group.id];
+          const hasActiveChild = group.items.some(
+            (item) => item.route === pathname
+          );
+          const Icon = hasActiveChild ? group.activeIcon : group.icon;
+          return (
+            <div key={group.id} className={styles.group}>
+              <button
+                type="button"
+                aria-expanded={isOpen}
+                className={styles.item}
+                onClick={() => toggleGroup(group.id)}
+              >
+                <span className={styles.icon}>
+                  <Icon />
+                </span>
+                <span className={styles.label}>{group.label}</span>
+                <ChevronRightRegular
+                  className={mergeClasses(
+                    styles.chevron,
+                    isOpen && styles.chevronOpen
+                  )}
+                />
+              </button>
+              {isOpen && (
+                <div className={styles.subGroup}>
+                  {group.items.map((item) => {
+                    const active = pathname === item.route;
+                    return (
+                      <button
+                        key={item.route}
+                        type="button"
+                        aria-current={active ? "page" : undefined}
+                        className={mergeClasses(
+                          styles.subItem,
+                          active && styles.subItemActive
+                        )}
+                        onClick={() => navigate(item.route)}
+                      >
+                        {item.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
 
-        <NavCategory value="styles">
-          <NavCategoryItem icon={<SlideTextRegular />}>Styles</NavCategoryItem>
-          <NavSubItemGroup className={styles.subItemGroup}>
-            <NavSubItem value={routes.mainMenu}>Main menu</NavSubItem>
-            <NavSubItem value={routes.TableUtilities}>Table</NavSubItem>
-            <NavSubItem value={routes.TabListUtilities}>Tablist</NavSubItem>
-          </NavSubItemGroup>
-        </NavCategory>
-      </NavDrawerBody>
-      <NavDrawerFooter className={styles.footer}>
+      <div className={styles.footer}>
         <Link href={GitHubUrls.home} className={styles.footerIcon}>
           <svg
             aria-hidden="true"
@@ -149,14 +362,14 @@ export function NavigationMenu({ ...rest }) {
             width="20"
           >
             <path
-              fill={tokens.colorNeutralForeground3}
+              fill="currentColor"
               fillRule="evenodd"
               d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
             />
           </svg>
         </Link>
         <Caption1 className={styles.footerText}>@axiscommunications</Caption1>
-      </NavDrawerFooter>
-    </NavDrawer>
+      </div>
+    </nav>
   );
 }

--- a/examples/src/components/story/story-code-copy.tsx
+++ b/examples/src/components/story/story-code-copy.tsx
@@ -1,36 +1,5 @@
-import {
-  Button,
-  ButtonProps,
-  Tooltip,
-  makeStyles,
-  mergeClasses,
-  tokens,
-} from "@fluentui/react-components";
-import { RectangleLandscapeHintCopyFilled } from "@fluentui/react-icons";
-import React, { useCallback } from "react";
-
-const componentId = "copy";
-export const copyClassNames = {
-  root: componentId,
-};
-
-const useStyles = makeStyles({
-  root: {
-    "&:hover": {
-      color: tokens.colorBrandBackground,
-    },
-  },
-});
-
-type TUseCopyStyles = {
-  className?: string;
-};
-
-export function useCopyStyles({ className }: TUseCopyStyles) {
-  const styles = useStyles();
-  const rootStyle = mergeClasses(copyClassNames.root, styles.root, className);
-  return { styles, rootStyle };
-}
+import { ButtonProps } from "@fluentui/react-components";
+import { CopyButton as BaseCopyButton } from "../copy-button";
 
 type TCopy = {
   codeString: string;
@@ -38,35 +7,13 @@ type TCopy = {
 } & Pick<ButtonProps, "shape" | "appearance">;
 
 export function CopyButton({ className, codeString, ...rest }: TCopy) {
-  const { rootStyle } = useCopyStyles({ className });
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: FIXME
-  const copyCode = useCallback(
-    async (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-      e.stopPropagation();
-      e.preventDefault();
-      await copyToClipboard(codeString);
-    },
-    []
-  );
-
   return (
-    <Tooltip withArrow content={"copy codeblock"} relationship={"label"}>
-      <Button
-        className={rootStyle}
-        shape="circular"
-        onClick={copyCode}
-        icon={<RectangleLandscapeHintCopyFilled />}
-        {...rest}
-      ></Button>
-    </Tooltip>
+    <BaseCopyButton
+      value={codeString}
+      className={className}
+      copyLabel="Copy code"
+      shape="circular"
+      {...rest}
+    />
   );
-}
-
-async function copyToClipboard(text: string): Promise<void> {
-  try {
-    await navigator.clipboard.writeText(text);
-  } catch (error) {
-    console.error("Error copying to clipboard:", error);
-  }
 }

--- a/examples/src/components/top-bar.tsx
+++ b/examples/src/components/top-bar.tsx
@@ -12,9 +12,9 @@ import {
   TopBar,
 } from "@axiscommunications/fluent-topbar";
 import {
-  Button,
   Menu,
   MenuButton,
+  MenuDivider,
   MenuItem,
   MenuList,
   MenuPopover,
@@ -26,14 +26,13 @@ import {
   AddRegular,
   AnimalCat20Filled,
   AnimalCat20Regular,
+  AppsListRegular,
   BuildingBank20Regular,
-  Drawer24Filled,
+  Drawer24Regular,
   FoodApple24Regular,
-  FoodCarrot20Filled,
   FoodFish20Filled,
   FoodFish20Regular,
   MailUnreadFilled,
-  Megaphone24Filled,
   OpenRegular,
   QuestionCircleRegular,
   ZoomFit20Filled,
@@ -115,7 +114,7 @@ export const Navbar = () => {
     ...new Array<LanguageOption>(50).fill({ id: "fi" }),
   ];
 
-  const [selectedApp, setSelectedApp] = useState(applications[1].id);
+  const [selectedApp, setSelectedApp] = useState(applications[0].id);
   const [drawerSelectedApp, setDrawerSelectedApp] = useState(
     appDrawerContent[1].id
   );
@@ -190,36 +189,9 @@ export const Navbar = () => {
           onChange: onNavigateToApplication,
         }}
         applicationArea={"mySystems"}
-        leftCustomContent={
-          <>
-            <Button
-              appearance="subtle"
-              icon={<Megaphone24Filled />}
-              iconPosition="before"
-              onClick={() => setShowDrawer(!showDrawer)}
-            >
-              {showDrawer ? "Use application menu" : "Use application drawer"}
-            </Button>
-            <Button
-              appearance="subtle"
-              icon={<Drawer24Filled />}
-              onClick={() =>
-                setDrawerVersion((prev) => {
-                  return prev === "v1"
-                    ? "v2"
-                    : prev === "v2"
-                      ? undefined
-                      : "v1";
-                })
-              }
-            >
-              {`Drawer version: ${drawerVersion}`}
-            </Button>
-          </>
-        }
         customContent={
           <Menu>
-            <MenuTrigger>
+            <MenuTrigger disableButtonEnhancement>
               <MenuButton
                 icon={<QuestionCircleRegular />}
                 appearance="subtle"
@@ -228,12 +200,29 @@ export const Navbar = () => {
             <MenuPopover>
               <MenuList>
                 <MenuItem>FAQ</MenuItem>
+                <MenuDivider />
+                <MenuItem
+                  icon={<AppsListRegular />}
+                  onClick={() => setShowDrawer((prev) => !prev)}
+                >
+                  {showDrawer
+                    ? "Demo: use application menu"
+                    : "Demo: use application drawer"}
+                </MenuItem>
+                <MenuItem
+                  icon={<Drawer24Regular />}
+                  disabled={!showDrawer}
+                  onClick={() =>
+                    setDrawerVersion((prev) =>
+                      prev === "v1" ? "v2" : prev === "v2" ? undefined : "v1"
+                    )
+                  }
+                >
+                  {`Demo: drawer version ${drawerVersion ?? "off"}`}
+                </MenuItem>
               </MenuList>
             </MenuPopover>
           </Menu>
-        }
-        centerCustomContent={
-          <Button icon={<FoodCarrot20Filled />}>I AM CENTER</Button>
         }
         orgMenu={{
           customContent: (

--- a/examples/src/landingpage/index.tsx
+++ b/examples/src/landingpage/index.tsx
@@ -10,6 +10,7 @@ import {
   DocumentCssRegular,
   IconsRegular,
   PuzzlePieceRegular,
+  SparkleRegular,
 } from "@fluentui/react-icons";
 import { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
@@ -39,7 +40,21 @@ const useStyles = makeStyles({
     display: "flex",
     flexDirection: "column",
     ...shorthands.gap(tokens.spacingVerticalM),
-    maxWidth: "520px",
+    maxWidth: "640px",
+  },
+  kicker: {
+    display: "inline-flex",
+    alignItems: "center",
+    alignSelf: "flex-start",
+    ...shorthands.gap(tokens.spacingHorizontalXS),
+    ...shorthands.padding(tokens.spacingVerticalXXS, tokens.spacingHorizontalS),
+    ...shorthands.borderRadius(tokens.borderRadiusCircular),
+    backgroundColor: tokens.colorBrandBackground2,
+    color: tokens.colorBrandForeground1,
+    fontSize: tokens.fontSizeBase200,
+    fontWeight: tokens.fontWeightSemibold,
+    textTransform: "uppercase",
+    letterSpacing: "0.04em",
   },
   title: {
     fontSize: tokens.fontSizeHero800,
@@ -49,12 +64,13 @@ const useStyles = makeStyles({
   },
   subtitle: {
     color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase400,
   },
   cardContainer: {
     display: "grid",
     gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))",
     ...shorthands.gap(tokens.spacingHorizontalL),
-    maxWidth: "900px",
+    maxWidth: "980px",
   },
 });
 
@@ -72,6 +88,10 @@ export const WelcomePage = () => {
     <div data-testid={TestId.welcomePage} className={styles.root}>
       <div className={styles.content}>
         <div className={styles.hero}>
+          <span className={styles.kicker}>
+            <SparkleRegular />
+            Axis Design System
+          </span>
           <span className={styles.title}>
             Welcome to Axis Fluent Components
           </span>

--- a/examples/src/landingpage/welcome-card.tsx
+++ b/examples/src/landingpage/welcome-card.tsx
@@ -3,6 +3,7 @@ import {
   Card,
   Subtitle2,
   makeStyles,
+  mergeClasses,
   shorthands,
   tokens,
 } from "@fluentui/react-components";
@@ -14,48 +15,48 @@ const useStyles = makeStyles({
     position: "relative",
     minWidth: "200px",
     maxWidth: "100%",
-    height: "auto",
-    minHeight: "170px",
+    minHeight: "180px",
     ...shorthands.padding(tokens.spacingVerticalXL, tokens.spacingHorizontalXL),
-    ...shorthands.gap(tokens.spacingVerticalXS),
+    ...shorthands.gap(tokens.spacingVerticalS),
     ...shorthands.overflow("hidden"),
     cursor: "pointer",
     transitionDuration: tokens.durationNormal,
-    transitionProperty: "background, box-shadow",
+    transitionProperty: "background, box-shadow, transform",
     display: "flex",
     flexDirection: "column",
-    justifyContent: "flex-end",
+    alignItems: "flex-start",
     ":hover": {
       backgroundColor: tokens.colorNeutralBackground1Hover,
       boxShadow: tokens.shadow16,
+      transform: "translateY(-2px)",
     },
-    ":hover > :first-child": {
-      transform: "rotate(-8deg) scale(1.15)",
-      opacity: "0.18",
+    ":hover .axis-WelcomeCard__icon": {
+      backgroundColor: tokens.colorBrandBackground,
+      color: tokens.colorNeutralForegroundOnBrand,
     },
-    ":hover > :last-child > svg": {
+    ":hover .axis-WelcomeCard__footer svg": {
       transform: "translateX(4px)",
     },
   },
-  watermark: {
-    position: "absolute",
-    top: "-8px",
-    right: "-8px",
-    fontSize: "96px",
-    opacity: "0.1",
+  icon: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "44px",
+    height: "44px",
+    ...shorthands.borderRadius(tokens.borderRadiusLarge),
+    backgroundColor: tokens.colorBrandBackground2,
     color: tokens.colorBrandForeground1,
+    fontSize: "24px",
     transitionDuration: tokens.durationNormal,
-    transitionProperty: "transform, opacity",
-    pointerEvents: "none",
-    lineHeight: "1",
+    transitionProperty: "background, color",
   },
   title: {
-    color: tokens.colorBrandForeground1,
-    position: "relative",
+    color: tokens.colorNeutralForeground1,
   },
   description: {
-    color: tokens.colorNeutralForeground2,
-    position: "relative",
+    color: tokens.colorNeutralForeground3,
+    flexGrow: 1,
   },
   footer: {
     display: "flex",
@@ -64,8 +65,6 @@ const useStyles = makeStyles({
     color: tokens.colorBrandForeground1,
     fontSize: tokens.fontSizeBase200,
     fontWeight: tokens.fontWeightSemibold,
-    marginTop: tokens.spacingVerticalS,
-    position: "relative",
     "& svg": {
       transitionDuration: tokens.durationNormal,
       transitionProperty: "transform",
@@ -90,10 +89,12 @@ export const WelcomeCard = ({
 
   return (
     <Card className={styles.root} onClick={onClick}>
-      <div className={styles.watermark}>{icon}</div>
+      <div className={mergeClasses("axis-WelcomeCard__icon", styles.icon)}>
+        {icon}
+      </div>
       <Subtitle2 className={styles.title}>{title}</Subtitle2>
       <Body1 className={styles.description}>{description}</Body1>
-      <div className={styles.footer}>
+      <div className={mergeClasses("axis-WelcomeCard__footer", styles.footer)}>
         Explore <ArrowRightRegular />
       </div>
     </Card>

--- a/examples/src/stories/icons/components/icon-copy.tsx
+++ b/examples/src/stories/icons/components/icon-copy.tsx
@@ -1,6 +1,4 @@
-import { Button, Tooltip } from "@fluentui/react-components";
-import { RectangleLandscapeHintCopyRegular } from "@fluentui/react-icons";
-import { useCallback } from "react";
+import { CopyButton } from "../../../components/copy-button";
 
 type TIconCopy = {
   toolTip: string;
@@ -8,26 +6,11 @@ type TIconCopy = {
 };
 
 export function IIconCopy({ toolTip, toCopy }: TIconCopy) {
-  // biome-ignore lint/correctness/useExhaustiveDependencies: FIXME
-  const copyCode = useCallback(async () => {
-    toCopy && (await copyToClipboard(`<${toCopy}/>`));
-  }, []);
-
   return (
-    <Tooltip withArrow content={toolTip} relationship={"label"}>
-      <Button
-        appearance="transparent"
-        onClick={copyCode}
-        icon={<RectangleLandscapeHintCopyRegular />}
-      ></Button>
-    </Tooltip>
+    <CopyButton
+      value={toCopy ? `<${toCopy}/>` : ""}
+      copyLabel={toolTip}
+      appearance="transparent"
+    />
   );
-}
-
-async function copyToClipboard(text: string): Promise<void> {
-  try {
-    await navigator.clipboard.writeText(text);
-  } catch (error) {
-    console.error("Error copying to clipboard:", error);
-  }
 }

--- a/examples/src/stories/illustrations/components/illustration-copy.tsx
+++ b/examples/src/stories/illustrations/components/illustration-copy.tsx
@@ -1,6 +1,4 @@
-import { Button, Tooltip } from "@fluentui/react-components";
-import { RectangleLandscapeHintCopyRegular } from "@fluentui/react-icons";
-import { useCallback } from "react";
+import { CopyButton } from "../../../components/copy-button";
 
 type TIllustrationCopy = {
   toolTip: string;
@@ -8,26 +6,11 @@ type TIllustrationCopy = {
 };
 
 export function IllustrationCopy({ toolTip, toCopy }: TIllustrationCopy) {
-  // biome-ignore lint/correctness/useExhaustiveDependencies: FIXME
-  const copyCode = useCallback(async () => {
-    toCopy && (await copyToClipboard(`<${toCopy}/>`));
-  }, []);
-
   return (
-    <Tooltip withArrow content={toolTip} relationship={"label"}>
-      <Button
-        appearance="transparent"
-        onClick={copyCode}
-        icon={<RectangleLandscapeHintCopyRegular />}
-      ></Button>
-    </Tooltip>
+    <CopyButton
+      value={toCopy ? `<${toCopy}/>` : ""}
+      copyLabel={toolTip}
+      appearance="transparent"
+    />
   );
-}
-
-async function copyToClipboard(text: string): Promise<void> {
-  try {
-    await navigator.clipboard.writeText(text);
-  } catch (error) {
-    console.error("Error copying to clipboard:", error);
-  }
 }

--- a/examples/src/stories/theme/components/color-tokens.tsx
+++ b/examples/src/stories/theme/components/color-tokens.tsx
@@ -5,6 +5,8 @@ import {
   shorthands,
   tokens,
 } from "@fluentui/react-components";
+import { ReactNode } from "react";
+import { CopyButton } from "../../../components/copy-button";
 import { TaxisThemeVariants } from "../theme-page.types";
 
 const componentId = "color-tokens";
@@ -13,32 +15,76 @@ export const colorTokensClassNames = {
 };
 
 const useStyles = makeStyles({
-  root: {
-    display: "grid",
-    gridTemplateColumns: "2fr 1fr 1fr",
-    ...shorthands.gap(tokens.spacingHorizontalXS),
-    fontFamily: "monospace",
-    "> :nth-child(1)": {
-      gridColumnStart: "span 1",
-    },
-    "> :nth-child(2)": {
-      gridColumnStart: "span 1",
-    },
-    "> :nth-child(3)": {
-      gridColumnStart: "span 1",
-    },
+  section: {
+    display: "flex",
+    flexDirection: "column",
+    ...shorthands.gap(tokens.spacingVerticalXS),
+    marginBottom: tokens.spacingVerticalXL,
   },
-  tableHeader: {
-    fontSize: "16px",
+  sectionTitle: {
+    display: "flex",
+    alignItems: "center",
+    ...shorthands.gap(tokens.spacingHorizontalXS),
+    fontSize: tokens.fontSizeBase300,
+    fontWeight: tokens.fontWeightSemibold,
+    color: tokens.colorNeutralForeground2,
+    textTransform: "uppercase",
+    letterSpacing: "0.04em",
+    marginBottom: tokens.spacingVerticalXXS,
+  },
+  count: {
+    ...shorthands.padding(0, tokens.spacingHorizontalXS),
+    ...shorthands.borderRadius(tokens.borderRadiusCircular),
+    backgroundColor: tokens.colorNeutralBackground3,
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase100,
+    fontWeight: tokens.fontWeightRegular,
+    letterSpacing: "normal",
+    textTransform: "none",
+  },
+  empty: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    ...shorthands.gap(tokens.spacingVerticalXS),
+    ...shorthands.padding(tokens.spacingVerticalXXXL, 0),
+    color: tokens.colorNeutralForeground3,
+  },
+  emptyQuery: {
+    fontFamily: "monospace",
+    color: tokens.colorNeutralForeground1,
+  },
+  table: {
+    display: "grid",
+    gridTemplateColumns:
+      "minmax(240px, 2fr) minmax(140px, 1fr) minmax(140px, 1fr)",
+    ...shorthands.overflow("hidden"),
+    ...shorthands.borderRadius(tokens.borderRadiusMedium),
+    ...shorthands.border(
+      tokens.strokeWidthThin,
+      "solid",
+      tokens.colorNeutralStroke2
+    ),
     backgroundColor: tokens.colorNeutralBackground1,
+  },
+  headerCell: {
+    ...shorthands.padding(tokens.spacingVerticalS, tokens.spacingHorizontalM),
+    backgroundColor: tokens.colorNeutralBackground2,
+    fontSize: tokens.fontSizeBase200,
+    fontWeight: tokens.fontWeightSemibold,
+    color: tokens.colorNeutralForeground2,
+    ...shorthands.borderBottom(
+      tokens.strokeWidthThin,
+      "solid",
+      tokens.colorNeutralStroke2
+    ),
   },
 });
 
 export function useColorTokensStyles() {
   const styles = useStyles();
-  const rootStyle = mergeClasses(colorTokensClassNames.root, styles.root);
-  const headerStyle = mergeClasses(styles.root, styles.tableHeader);
-  return { styles, headerStyle, rootStyle };
+  const rootStyle = mergeClasses(colorTokensClassNames.root, styles.table);
+  return { styles, rootStyle };
 }
 
 type TColorTokens = {
@@ -47,112 +93,263 @@ type TColorTokens = {
 };
 
 export function ColorTokens({ theme, filter, ...rest }: TColorTokens) {
+  const styles = useStyles();
   const { light, dark } = theme;
 
-  const tokens = Object.entries(light)
-    .filter(([token]) => token.startsWith("color"))
-    .filter(([token, value]) => {
-      const keyHit = token.toLowerCase().includes(filter.toLowerCase());
-      const valueHit = value
-        .toString()
-        .toLowerCase()
-        .includes(filter.toLowerCase());
-      return keyHit || valueHit;
-    })
-    .map(([token, value]) => ({
-      token,
-      lightValue: value as string,
-      darkValue: (dark as unknown as Record<string, string>)[token],
-    }));
+  const toRows = (prefix: string) =>
+    Object.entries(light)
+      .filter(([token]) => token.startsWith(prefix))
+      .map(([token, value]) => ({
+        token,
+        lightValue: value as string,
+        darkValue: (dark as unknown as Record<string, string>)[token],
+      }))
+      .filter((row) => matchesFilter(row, filter));
 
-  const customColorTokens = Object.entries(light)
-    .filter(([token]) => token.startsWith("axisCustomColor"))
-    .map(([token, value]) => ({
-      token,
-      lightValue: value as string,
-      darkValue: (dark as unknown as Record<string, string>)[token],
-    }));
+  const customColorTokens = toRows("axisCustomColor");
+  const customUtilityTokens = toRows("axisCustomUtility");
+  const fluentTokens = toRows("color");
 
-  const customUtilityTokens = Object.entries(light)
-    .filter(([token]) => token.startsWith("axisCustomUtility"))
-    .map(([token, value]) => ({
-      token,
-      lightValue: value as string,
-      darkValue: (dark as unknown as Record<string, string>)[token],
-    }));
-
-  const { rootStyle } = useColorTokensStyles();
+  const isEmpty =
+    customColorTokens.length === 0 &&
+    customUtilityTokens.length === 0 &&
+    fluentTokens.length === 0;
 
   return (
-    <>
-      <Header title="custom color token" />
-      <div data-testid={componentId} className={rootStyle} {...rest}>
-        {customColorTokens.map((args, i) => (
-          <ColorPalette key={i} {...args} />
-        ))}
-      </div>
+    <div data-testid={componentId} {...rest}>
+      {isEmpty ? (
+        <div className={styles.empty}>
+          <span>No tokens match</span>
+          <span className={styles.emptyQuery}>"{filter}"</span>
+        </div>
+      ) : (
+        <>
+          <TokenSection
+            title="Custom color tokens"
+            rows={customColorTokens}
+            filter={filter}
+          />
+          <TokenSection
+            title="Custom utility tokens"
+            rows={customUtilityTokens}
+            filter={filter}
+          />
+          <TokenSection
+            title="Fluent tokens"
+            rows={fluentTokens}
+            filter={filter}
+          />
+        </>
+      )}
+    </div>
+  );
+}
 
-      <Header title="custom utility token" />
-      <div data-testid={componentId} className={rootStyle} {...rest}>
-        {customUtilityTokens.map((args, i) => (
-          <ColorPalette key={i} {...args} />
-        ))}
-      </div>
+type TColorPalette = { token: string; lightValue: string; darkValue: string };
 
-      <Header title="token" />
-      <div data-testid={componentId} className={rootStyle} {...rest}>
-        {tokens.map((args, i) => (
-          <ColorPalette key={i} {...args} />
+function matchesFilter(row: TColorPalette, filter: string) {
+  if (!filter) {
+    return true;
+  }
+  const needle = filter.toLowerCase();
+  return (
+    row.token.toLowerCase().includes(needle) ||
+    (row.lightValue ?? "").toLowerCase().includes(needle) ||
+    (row.darkValue ?? "").toLowerCase().includes(needle)
+  );
+}
+
+function TokenSection({
+  title,
+  rows,
+  filter,
+}: {
+  title: string;
+  rows: TColorPalette[];
+  filter: string;
+}) {
+  const styles = useStyles();
+  const { rootStyle } = useColorTokensStyles();
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.section}>
+      <span className={styles.sectionTitle}>
+        {title}
+        <span className={styles.count}>{rows.length}</span>
+      </span>
+      <div className={rootStyle}>
+        <div className={styles.headerCell}>Token</div>
+        <div className={styles.headerCell}>Light</div>
+        <div className={styles.headerCell}>Dark</div>
+        {rows.map((args, i) => (
+          <ColorPalette
+            key={args.token}
+            zebra={i % 2 === 1}
+            filter={filter}
+            {...args}
+          />
         ))}
       </div>
-    </>
+    </div>
   );
 }
 
 const useColorPaletteStyles = makeStyles({
-  root: {
-    width: "100%",
-    textShadow: "0px 0px 1px #fff, 0 0px 1px #000, 0 0 0px",
+  tokenCell: {
+    display: "flex",
+    alignItems: "center",
+    ...shorthands.gap(tokens.spacingHorizontalXS),
+    ...shorthands.padding(
+      tokens.spacingVerticalSNudge,
+      tokens.spacingHorizontalM,
+      tokens.spacingVerticalSNudge,
+      tokens.spacingHorizontalXS
+    ),
+    fontFamily: "monospace",
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground1,
+    ...shorthands.overflow("hidden"),
+    animationName: {
+      from: { opacity: 0, transform: "translateY(4px)" },
+      to: { opacity: 1, transform: "translateY(0)" },
+    },
+    animationDuration: tokens.durationNormal,
+    animationTimingFunction: tokens.curveDecelerateMin,
+    animationFillMode: "both",
+  },
+  tokenName: {
+    ...shorthands.overflow("hidden"),
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  copyButton: {
+    minWidth: "24px",
+    maxWidth: "24px",
+    height: "24px",
+    flexShrink: 0,
+    ...shorthands.padding(0),
+  },
+  valueCell: {
+    display: "flex",
+    alignItems: "center",
+    ...shorthands.gap(tokens.spacingHorizontalS),
+    ...shorthands.padding(
+      tokens.spacingVerticalSNudge,
+      tokens.spacingHorizontalM
+    ),
+    fontFamily: "monospace",
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground2,
+    animationName: {
+      from: { opacity: 0, transform: "translateY(4px)" },
+      to: { opacity: 1, transform: "translateY(0)" },
+    },
+    animationDuration: tokens.durationNormal,
+    animationTimingFunction: tokens.curveDecelerateMin,
+    animationFillMode: "both",
+  },
+  zebra: {
+    backgroundColor: tokens.colorNeutralBackground2,
+  },
+  swatch: {
+    flexShrink: 0,
+    width: "18px",
+    height: "18px",
+    ...shorthands.borderRadius(tokens.borderRadiusSmall),
+    ...shorthands.border(
+      tokens.strokeWidthThin,
+      "solid",
+      tokens.colorNeutralStroke1
+    ),
+    boxShadow: tokens.shadow2,
+  },
+  mark: {
+    ...shorthands.padding(0, "2px"),
+    ...shorthands.borderRadius(tokens.borderRadiusSmall),
+    backgroundColor: tokens.colorBrandBackground,
+    color: tokens.colorNeutralForegroundOnBrand,
+    fontWeight: tokens.fontWeightSemibold,
   },
 });
 
-type TColorPalette = { token: string; lightValue: string; darkValue: string };
-
-function ColorPalette({ token, lightValue, darkValue }: TColorPalette) {
+function Highlight({ text, query }: { text: string; query: string }) {
   const styles = useColorPaletteStyles();
+
+  if (!query || !text) {
+    return <>{text}</>;
+  }
+
+  const lowerText = text.toLowerCase();
+  const needle = query.toLowerCase();
+  const parts: ReactNode[] = [];
+  let cursor = 0;
+  let matchIndex = lowerText.indexOf(needle);
+
+  while (matchIndex !== -1) {
+    if (matchIndex > cursor) {
+      parts.push(text.slice(cursor, matchIndex));
+    }
+    const end = matchIndex + needle.length;
+    parts.push(
+      <mark key={matchIndex} className={styles.mark}>
+        {text.slice(matchIndex, end)}
+      </mark>
+    );
+    cursor = end;
+    matchIndex = lowerText.indexOf(needle, cursor);
+  }
+
+  if (cursor < text.length) {
+    parts.push(text.slice(cursor));
+  }
+
+  return <>{parts}</>;
+}
+
+function ColorPalette({
+  token,
+  lightValue,
+  darkValue,
+  zebra,
+  filter,
+}: TColorPalette & {
+  zebra: boolean;
+  filter: string;
+}) {
+  const styles = useColorPaletteStyles();
+  const rowStyle = zebra ? styles.zebra : undefined;
 
   return (
     <>
-      <div>{token}</div>
-      <div
-        className={styles.root}
-        style={{
-          backgroundColor: lightValue,
-          color: darkValue,
-        }}
-      >
-        {lightValue}
+      <div className={mergeClasses(styles.tokenCell, rowStyle)}>
+        <CopyButton
+          value={token}
+          size="small"
+          copyLabel="Copy token"
+          className={styles.copyButton}
+        />
+        <span className={styles.tokenName}>
+          <Highlight text={token} query={filter} />
+        </span>
       </div>
-      <div
-        className={styles.root}
-        style={{
-          backgroundColor: darkValue,
-          color: lightValue,
-        }}
-      >
-        {darkValue}
+      <div className={mergeClasses(styles.valueCell, rowStyle)}>
+        <span
+          className={styles.swatch}
+          style={{ backgroundColor: lightValue }}
+        />
+        <Highlight text={lightValue} query={filter} />
+      </div>
+      <div className={mergeClasses(styles.valueCell, rowStyle)}>
+        <span
+          className={styles.swatch}
+          style={{ backgroundColor: darkValue }}
+        />
+        <Highlight text={darkValue} query={filter} />
       </div>
     </>
-  );
-}
-
-function Header({ title }: { title: string }) {
-  const { headerStyle } = useColorTokensStyles();
-  return (
-    <div className={headerStyle}>
-      <b>{title}</b>
-      <b>light value</b>
-      <b>dark value</b>
-    </div>
   );
 }


### PR DESCRIPTION
## Summary

UI/UX pass on the examples app, focused on the side navigation, landing page, and theme token page, plus a unified copy button.

### Side navigation
- Rebuilt the sidebar as a custom component (no more `NavDrawer`) so icons and labels align consistently.
- Active item highlight (brand tint + filled icon + left accent bar), hover/pressed states, collapsible Components/Styles groups with an animated chevron and a sub-item guide line.
- Slimmer width and a lighter panel surface; unified the far-left icon rail onto the same surface (no more black stripe).

### Top bar
- Removed the clipped placeholder controls ("Use application menu", "Drawer version", "I AM CENTER") and moved the demo toggles into the help menu.
- Defaults to the labeled application.

### Landing page
- Brand kicker pill, tightened hero hierarchy, and cleaner cards (icon badge instead of a rotating watermark).

### Theme token page
- Search now filters **all** sections (custom color, custom utility, and Fluent tokens), matching on token name and both values.
- Matched substrings are highlighted, each section shows a live count, and there's an empty state plus a subtle row entrance animation.
- Rebuilt the token list as a readable table with swatch chips.

### Shared copy button
- Added `examples/src/components/copy-button.tsx` with consistent styling and a "Copied!" checkmark confirmation.
- Reused it for token, icon, illustration, and code-block copy actions (previously three separate implementations with an inconsistent icon and no feedback).

## Verification
- `pnpm format`, `pnpm --filter examples lint` (tsc + Biome), `pnpm test`, and `pnpm build` all pass.
- Verified interactively in the dev server.