### PR TITLE
fix(ci): stop main deploy from force-wiping gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      issues: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,13 +28,20 @@ jobs:
           pnpm install --frozen-lockfile
 
       - name: Build example project
-        run: pnpm --filter examples build:deploy
+        run: pnpm --filter examples build
+
+      - name: Stage Pages artifact
+        run: |
+          mkdir -p publish/docs
+          cp -r examples/dist/. publish/
+          cp -r examples/dist/. publish/docs/
+          touch publish/.nojekyll
+          touch publish/docs/.nojekyll
 
       - name: Deploy example page to gh-pages
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git switch --orphan gh-pages
-          git add -f docs
-          git commit -m "docs: update examplepage"
-          git push -f origin gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./publish
+          keep_files: true


### PR DESCRIPTION
## Problem
The examples deploy workflow (`.github/workflows/deploy.yml`, triggered on push to `main`) republishes GitHub Pages by doing:

```
git switch --orphan gh-pages
git add -f docs
git push -f origin gh-pages
```

This **force-recreates the entire `gh-pages` branch** on every `main` deploy, keeping only `docs/`. Any other content published to `gh-pages` (e.g. the Storybook at `/storybook` deployed from the `dev-design-storybook` branch) is deleted each time `main` deploys.

## Fix
Replace the destructive orphan force-push with `peaceiris/actions-gh-pages@v4` using `keep_files: true`, and publish the built examples app to both the branch root and `/docs` (with `.nojekyll`).

- CI-only change — one file, no application/feature code.
- `main` deploys now update only the examples app and leave unrelated Pages content (Storybook) intact.

## Result
- Examples app + Storybook coexist on `gh-pages` and no longer wipe each other.