### PR TITLE
fix(ci): stop main deploy from force-wiping gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      issues: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,13 +28,20 @@ jobs:
           pnpm install --frozen-lockfile
 
       - name: Build example project
-        run: pnpm --filter examples build:deploy
+        run: pnpm --filter examples build
+
+      - name: Stage Pages artifact
+        run: |
+          mkdir -p publish/docs
+          cp -r examples/dist/. publish/
+          cp -r examples/dist/. publish/docs/
+          touch publish/.nojekyll
+          touch publish/docs/.nojekyll
 
       - name: Deploy example page to gh-pages
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git switch --orphan gh-pages
-          git add -f docs
-          git commit -m "docs: update examplepage"
-          git push -f origin gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./publish
+          keep_files: true


### PR DESCRIPTION
Replaces the destructive `git switch --orphan gh-pages` + `git push -f` in `.github/workflows/deploy.yml` with `peaceiris/actions-gh-pages@v4` and `keep_files: true`, publishing the examples app to both the gh-pages root and `/docs`.

This stops every `main` deploy from wiping unrelated Pages content (the Storybook published under `/storybook` from `dev-design-storybook`).

CI-only change, one file. Single verified/signed commit. (Supersedes #619, which auto-closed when its branch was reset during signing.)