### PR TITLE
Set default workflow token permissions to read-only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   docs-gh-pages:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify-icons.yml
+++ b/.github/workflows/verify-icons.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify-illustrations.yml
+++ b/.github/workflows/verify-illustrations.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify-page.yml
+++ b/.github/workflows/verify-page.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   verify-gh-page:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify-tokens.yml
+++ b/.github/workflows/verify-tokens.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request applies the OSSF Scorecard **Token-Permissions** remedy.

It sets the default workflow token to read-only by adding a top-level `permissions` block to workflows that lacked one:

- `.github/workflows/deploy.yml`
- `.github/workflows/publish.yml`
- `.github/workflows/verify-icons.yml`
- `.github/workflows/verify-illustrations.yml`
- `.github/workflows/verify-page.yml`
- `.github/workflows/verify-tokens.yml`
- `.github/workflows/verify.yml`

Any job that needs more than read access must be granted those permissions at the job level, otherwise it may fail.

See the [OSSF Scorecard guidance](https://github.com/AxisCommunications/github-governance/blob/main/ossf-scorecard/README.md#token-permissions) for details.